### PR TITLE
Add a tab-to-space fixer

### DIFF
--- a/lib/Agrammon/TabFixer.pm6
+++ b/lib/Agrammon/TabFixer.pm6
@@ -1,0 +1,13 @@
+#| Fixes any tabs in the input string to four spaces, and warns about each
+#| one.
+sub fix-tabs(Str $in) is export {
+    return $in.subst(:g, /\t/, {
+        state @line-starts = $in.split(/<?[\n]>/).map(*.chars);
+        my $line = 1 + @line-starts.first(:k, {
+            state $cur-pos += $_;
+            $/.pos < $cur-pos
+        });
+        warn "Tab at line $line replaced with four spaces";
+        "    "
+    });
+}

--- a/t/fix-tabs.t
+++ b/t/fix-tabs.t
@@ -1,0 +1,34 @@
+use v6;
+use Agrammon::TabFixer;
+use Test;
+
+plan 6;
+
+{
+    my @warnings;
+    CONTROL {
+        when CX::Warn {
+            push @warnings, .message;
+        }
+    }
+    is fix-tabs("no problemo   \nno tabs here!\n"),
+        "no problemo   \nno tabs here!\n",
+        'No tabs in input means no changes';
+    is @warnings.elems, 0, 'No warnings when no tabs to fix';
+}
+
+{
+    my @warnings;
+    CONTROL {
+        when CX::Warn {
+            push @warnings, .message;
+            .resume;
+        }
+    }
+    is fix-tabs("a tab\ton first\nsecond ok\n\t at start of third\n"),
+        "a tab    on first\nsecond ok\n     at start of third\n",
+        'Tabs in input changed to four spaces';
+    is @warnings.elems, 2, 'A warning for each of the tabs fixed';
+    like @warnings[0], /'line 1'/, 'Line number of tab reported in warning (1)';
+    like @warnings[1], /'line 3'/, 'Line number of tab reported in warning (2)';
+}


### PR DESCRIPTION
Warns on each tab that is fixed up to be four spaces. We'll use this after reading module files and others from disk, before feeding them to the parser.