### PR TITLE
Parse external section of modules

### DIFF
--- a/lib/Agrammon/Model/External.pm6
+++ b/lib/Agrammon/Model/External.pm6
@@ -1,0 +1,3 @@
+class Agrammon::Model::External {
+    has Str $.name;
+}

--- a/lib/Agrammon/Model/Module.pm6
+++ b/lib/Agrammon/Model/Module.pm6
@@ -1,4 +1,5 @@
 use v6;
+use Agrammon::Model::External;
 use Agrammon::Model::Input;
 use Agrammon::Model::Test;
 use Agrammon::Model::Output;
@@ -10,6 +11,7 @@ class Agrammon::Model::Module {
     has Str $.taxonomy;
     has Str $.short;
     has Str $.description;
+    has Agrammon::Model::External @.external;
     has Agrammon::Model::Input @.input;
     has Agrammon::Model::Technical @.technical;
     has Agrammon::Model::Output @.output;

--- a/lib/Agrammon/ModuleBuilder.pm6
+++ b/lib/Agrammon/ModuleBuilder.pm6
@@ -1,4 +1,5 @@
 use v6;
+use Agrammon::Model::External;
 use Agrammon::Model::Input;
 use Agrammon::Model::Module;
 use Agrammon::Model::Output;
@@ -12,6 +13,12 @@ class Agrammon::ModuleBuilder {
 
     method section:sym<general>($/) {
         make %( $<option>.map(*.ast) );
+    }
+
+    method section:sym<external>($/) {
+        make 'external' => $<external>.map({
+            Agrammon::Model::External.new(|.ast)
+        });
     }
 
     method section:sym<input>($/) {

--- a/lib/Agrammon/ModuleParser.pm6
+++ b/lib/Agrammon/ModuleParser.pm6
@@ -25,6 +25,14 @@ grammar Agrammon::ModuleParser {
         ]*
     }
 
+    token section:sym<external> {
+        <.section-heading('external')>
+        [
+        | <.blank-line>
+        | <external=.option-section>
+        ]*
+    }
+
     token section:sym<input> {
         <.section-heading('input')>
         [
@@ -58,7 +66,7 @@ grammar Agrammon::ModuleParser {
     }
 
     token option-section {
-        '+' <name=.ident> \h* \n
+        '+' <name> \h* \n
         [
         | <.blank-line>
         | '  ' <option=.single-line-option>
@@ -96,6 +104,10 @@ grammar Agrammon::ModuleParser {
                 \N* \n
             ]*
         ]
+    }
+
+    token name {
+        <.ident> [ '::' <.ident> ]*
     }
 
     token blank-line {

--- a/t/module-parser.t
+++ b/t/module-parser.t
@@ -104,6 +104,28 @@ given slurp($*PROGRAM.parent.add('test-data/CMilkWithTests.nhd')) -> $test-data 
         is .description, 'Test1',
             'Correct description for test';
     }
-
 }
+
+given slurp($*PROGRAM.parent.add('test-data/PlantProduction.nhd')) -> $test-data {
+    my $parsed = Agrammon::ModuleParser.parse($test-data, actions => Agrammon::ModuleBuilder);
+    ok $parsed, 'Successfully parsed PlantProduction.nhd';
+
+    my $model = $parsed.ast;
+
+    isa-ok $model, Agrammon::Model::Module, 'Parsing results in a Module';
+
+    my @external = $model.external;
+    is @external.elems, 3, 'Found 3 externals';
+    for ^3 {
+        isa-ok @external[0], Agrammon::Model::External,
+            'External entry is correct model type';
+    }
+    is @external[0].name, 'PlantProduction::AgriculturalArea',
+        'Correct external name (1)';
+    is @external[1].name, 'PlantProduction::MineralFertiliser',
+        'Correct external name (2)';
+    is @external[2].name, 'PlantProduction::RecyclingFertiliser',
+        'Correct external name (3)';
+}
+
 done-testing;

--- a/t/test-data/PlantProduction.nhd
+++ b/t/test-data/PlantProduction.nhd
@@ -1,0 +1,159 @@
+*** general ***
+
+author   = Agrammon Group
+date     = 2008-05-07
+taxonomy = PlantProduction
+gui      = PlantProduction,Pflanzenbau,Production végétale,Plant production
+
++short
+
+  Computes the annual NH3 emission from plant production.
+  
++description 
+
+  This process summarizes the contribution of the plant production 
+  to the total NH3 emission.
+
+\subsubsection{Differences to DYNAMO}
+     
+
+*** external ***
+
++PlantProduction::AgriculturalArea
++PlantProduction::MineralFertiliser
++PlantProduction::RecyclingFertiliser
+
+
+*** input ***
+
+#+ignore 
+# type  = enum{ignore}
+#  ++labels 
+#    en = ignore
+#  ++units  
+#    en = -
+#  ++description
+#    Just a work around for modules without input parameters.
+
+*** output ***
+
++nh3_nplantproduction
+  format= %.0f
+  print = PlantProductionTotal
+  ++labels 
+    sort = 909
+    en = Total Plantproduction NH3-Emissions
+    de = Total Pflanzenproduktion NH3-Emission
+    fr = Emission de NH3 Total Production végétale
+  ++units  
+    en = kg N/year
+    de = kg N/Jahr
+    fr = kg N/an
+  ++description
+    Annual NH3 emission from plant production.
+  ++formula
+    Val(nh3_nagriculturalarea, PlantProduction::AgriculturalArea) +
+    Val(nh3_nmineralfertiliser, PlantProduction::MineralFertiliser) +
+    Val(nh3_nrecyclingfertiliser, PlantProduction::RecyclingFertiliser) 
+
++mineral_nitrogen_fertiliser_urea
+  format= %.0f
+  print= FluxSummaryPlantProduction
+  ++labels 
+    sort = 111
+    en = Amount of urea (kg N per year)
+    de = N-Verbrauch als Harnstoff pro Jahr auf dem Betrieb (kg N pro Jahr)
+    fr = Utilisation annuelle de N sous forme d'urée (en kg de N par année)
+  ++units  
+    en = kg N/year
+    de = kg N/Jahr
+    fr = kg N/an
+  ++description
+    Amount of urea in kg N per year.
+  ++formula
+    Val(mineral_nitrogen_fertiliser_urea, PlantProduction::MineralFertiliser);
+
+
++mineral_nitrogen_fertiliser_except_urea
+  format= %.0f
+  print= FluxSummaryPlantProduction
+  ++labels 
+    sort = 112
+    en = Amount of nitrogen fertiliser (except urea) (kg N per year)
+    de = N-Verbrauch von anderen mineralischen Stickstoffdüngern (ohne Harnstoff) pro Jahr auf dem Betrieb (kg N pro Jahr)
+    fr = Utilisation annuelle de N sous forme d'autres engrais minéraux azotés (sans urée)  (kg de N par année)
+  ++units  
+    en = kg N/year
+    de = kg N/Jahr
+    fr = kg N/an
+  ++description
+    Amount of nitrogen fertiliser (except urea) in kg N per year.
+  ++formula
+    Val(mineral_nitrogen_fertiliser_except_urea, PlantProduction::MineralFertiliser);
+ 
+
++compost 
+  format= %.0f
+  print= FluxSummaryPlantProductionPlus
+  ++labels 
+    sort = 113
+    en = Amount of compost (t fresh matter per year)
+    de = Kompost (t Frischsubstanz pro Jahr)
+    fr = Compost (en t matière fraîche par an)
+  ++units  
+    en = t/year
+    de = t/Jahr
+    fr = t/an
+  ++description
+    Amount of compost in t per year.
+  ++formula
+    Val(compost, PlantProduction::RecyclingFertiliser);
+ 
++solid_digestate
+  format= %.0f
+  print= FluxSummaryPlantProductionPlus
+  ++labels
+    sort = 114
+    en = Amount of solid digestate (t fresh matter per year)
+    de = Festes Gärgut (t Frischsubstanz pro Jahr)
+    fr = Quantité de digestats solides issus d'installations industrielles (en t matière fraîche par an) 
+  ++units  
+    en = t/year
+    de = t/Jahr
+    fr = t/an
+  ++description
+    Amount of Solid digestate in t per year.
+  ++formula
+    Val(solid_digestate, PlantProduction::RecyclingFertiliser);
+
++liquid_digestate
+  format= %.0f
+  print= FluxSummaryPlantProductionPlus
+  ++labels 
+    sort = 115
+    en = Amount of liquid digestate (m3 per year)
+    de = Flüssiges Gärgut (m3 pro Jahr)
+    fr = Quantité de digestats liquides issus d'installations industrielles (en m3 par an)
+  ++units  
+    en = m3/year
+    de = m3/Jahr
+    fr = m3/an
+  ++description
+    Amount of liquid digestate in m3 per year.
+  ++formula
+    Val(liquid_digestate, PlantProduction::RecyclingFertiliser);
+
++agricultural_area
+  format= %.0f
+  print= FluxSummaryPlantProductionPlus
+  ++labels 
+    sort = 116
+    en = Agricultural area (ha)
+    de = Landwirtschaftliche Nutzfläche (ha)
+    fr = Surface agricole utile (ha)
+  ++units  
+    en = ha
+  ++description
+   Agricultural area (ha).
+  ++formula
+    Val(agricultural_area, PlantProduction::AgriculturalArea);


### PR DESCRIPTION
Does what it says, plus a couple of bonuses:

* Fixed a parse bug in multi-line descriptions, which the module file I took for testing external parsing tripped over
* Added error reporting of the point that it gets confused in the parse