### PR TITLE
Retain simulation name and dataset ID from input

### DIFF
--- a/lib/Agrammon/DataSource/CSV.pm6
+++ b/lib/Agrammon/DataSource/CSV.pm6
@@ -22,7 +22,7 @@ class Agrammon::DataSource::CSV {
     }
 
     method !group-input(@group) {
-        my $input = Agrammon::Inputs.new;
+        my $input = Agrammon::Inputs.new(simulation-name => @group[0][0], dataset-id => @group[0][1]);
         for @group {
             if .[2] ~~ /^ (<-[\[]>+) '[' (<-[\[]>+) ']' ['::' (.+)] $/ {
                 $input.add-multi-input(~$0, ~$1, ~($2 // ''), .[3], maybe-numify(.[4]))

--- a/lib/Agrammon/Inputs.pm6
+++ b/lib/Agrammon/Inputs.pm6
@@ -27,6 +27,8 @@ class X::Agrammon::Inputs::Multi is Exception {
 }
 
 class Agrammon::Inputs {
+    has Str $.simulation-name;
+    has Str $.dataset-id;
     has Str $.instance-id;
     has %!single-inputs;
     has %!multi-input-lists;
@@ -69,7 +71,7 @@ class Agrammon::Inputs {
             $input = $_;
         }
         else {
-            $input = Agrammon::Inputs.new(:$instance-id);
+            $input = Agrammon::Inputs.new(:$instance-id, :$!simulation-name, :$!dataset-id);
             %!multi-input-lookup{$taxonomy}{$instance-id} = $input;
             push %!multi-input-lists{$taxonomy}, $input;
         }

--- a/t/datasource-csv.t
+++ b/t/datasource-csv.t
@@ -17,6 +17,8 @@ use Test;
 
     subtest 'Data set 1', {
         isa-ok @datasets[0], Agrammon::Inputs, 'Correct type';
+        is @datasets[0].simulation-name, 'TEST', 'Correct simulation name';
+        is @datasets[0].dataset-id, 1, 'Correct data set ID';
         is-deeply @datasets[0].input-hash-for('PlantProduction::AgriculturalArea'),
             { agricultural_area => 20 },
             'Correct data for PlantProduction::AgriculturalArea';
@@ -37,6 +39,8 @@ use Test;
 
     subtest 'Data set 2', {
         isa-ok @datasets[1], Agrammon::Inputs, 'Correct type';
+        is @datasets[1].simulation-name, 'TEST', 'Correct simulation name';
+        is @datasets[1].dataset-id, 2, 'Correct data set ID';
         is-deeply @datasets[1].input-hash-for('PlantProduction::AgriculturalArea'),
         { agricultural_area => 40 },
         'Correct data for PlantProduction::AgriculturalArea';
@@ -70,6 +74,8 @@ use Test;
 
     subtest 'Data set 1', {
         isa-ok @datasets[0], Agrammon::Inputs, 'Correct type';
+        is @datasets[0].simulation-name, '2010v2.1_20120425', 'Correct simulation name';
+        is @datasets[0].dataset-id, 2, 'Correct data set ID';
         my @input-list = @datasets[0].inputs-list-for('Livestock::DairyCow');
         is @input-list.elems, 2, 'Have 2 dairy cow inputs';
         is-deeply @input-list[0].input-hash-for('Livestock::DairyCow::Excretion::CConcentrates'),
@@ -89,6 +95,8 @@ use Test;
 
     subtest 'Data set 2', {
         isa-ok @datasets[1], Agrammon::Inputs, 'Correct type';
+        is @datasets[1].simulation-name, '2010v2.1_20120425', 'Correct simulation name';
+        is @datasets[1].dataset-id, 18, 'Correct data set ID';
         my @input-list = @datasets[1].inputs-list-for('Livestock::DairyCow');
         is @input-list.elems, 2, 'Have 2 dairy cow inputs';
         is-deeply @input-list[0].input-hash-for('Livestock::DairyCow::Excretion::CConcentrates'),


### PR DESCRIPTION
When parsing the input from CSV, retain these. Also various updates to
tests on account of making these required props of Agrammon::Inputs.