### PR TITLE
Make it easier to just run the non-DB tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+test:
+	prove -j8 -e 'perl6 -Ilib' t
+unit-test:
+	AGRAMMON_UNIT_TEST=1 prove -j8 -e 'perl6 -Ilib' t

--- a/t/datasource-db.t
+++ b/t/datasource-db.t
@@ -3,6 +3,13 @@ use Agrammon::DataSource::DB;
 use DB::Pg;
 use Test;
 
+plan 4;
+
+if %*ENV<AGRAMMON_UNIT_TEST> {
+    skip-rest 'Not a unit test';
+    exit;
+}
+
 my $db-host     = 'localhost';
 my $db-port     = '5432';
 my $db-user     = 'postgres';
@@ -60,9 +67,6 @@ transactionally {
     is @data.elems, $rowsExpected, "Found $rowsExpected rows in dataset $ag-user:$ag-dataset";
 
 }
-
-done-testing;
-
 
 
 sub prepare-test-db($user, $dataset) {

--- a/t/user.t
+++ b/t/user.t
@@ -2,9 +2,14 @@ use v6;
 use Agrammon::Config;
 use Agrammon::DB::User;
 use DB::Pg;
-
 use Test;
+
 plan 6;
+
+if %*ENV<AGRAMMON_UNIT_TEST> {
+    skip-rest 'Not a unit test';
+    exit;
+}
 
 my $cfg-file = "t/test-data/agrammon.cfg.yaml";
 my $username = 'fritz.zaucker@oetiker.ch';

--- a/t/webservice.t
+++ b/t/webservice.t
@@ -2,10 +2,15 @@ use v6;
 use Agrammon::Config;
 use Agrammon::Web::Service;
 use Agrammon::Web::SessionUser;
-
 use DB::Pg;
 use Test;
+
 plan 9;
+
+if %*ENV<AGRAMMON_UNIT_TEST> {
+    skip-rest 'Not a unit test';
+    exit;
+}
 
 my $cfg-file = "t/test-data/agrammon.cfg.yaml";
 my $username = 'fritz.zaucker@oetiker.ch';


### PR DESCRIPTION
Add an environment variable that they will bail out on, and then add a
Makefile with `make test` and `make unit-test` targets. The latter sets
the environment variable.