### PR TITLE
Improve technical parser by re-using module parser

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -14,6 +14,7 @@
         "Agrammon::ModuleParser": "lib/Agrammon/ModuleParser.pm6",
         "Agrammon::DB::Tag": "lib/Agrammon/DB/Tag.pm6",
         "Agrammon::Formula::Parser": "lib/Agrammon/Formula/Parser.pm6",
+        "Agrammon::CommonParser": "lib/Agrammon/CommonParser.pm6",
         "Agrammon::Model::Test": "lib/Agrammon/Model/Test.pm6",
         "Agrammon::DB::Tags": "lib/Agrammon/DB/Tags.pm6",
         "Agrammon::DataSource::CSV": "lib/Agrammon/DataSource/CSV.pm6",

--- a/lib/Agrammon/CommonParser.pm6
+++ b/lib/Agrammon/CommonParser.pm6
@@ -1,0 +1,64 @@
+role Agrammon::CommonParser {
+    method panic($message) {
+        die "$message near " ~ self.orig.substr(self.pos, 50).perl;
+    }
+
+    token section-heading($title) {
+        \h* '***' \h* $title \h* '***' \h* \n
+    }
+
+    token option-section {
+        \h* '+' \h* <name> \h* \n
+        [
+        | <.blank-line>
+        | <option=.single-line-option>
+        | <option=.subsection-map>
+        | <option=.multi-line-str-option('++')>
+        ]*
+    }
+
+    token single-line-option {
+        \h* <key> \h* '=' \h* $<value>=[\N*] [\n || $]
+    }
+    token subsection-map {
+        \h* '++' \h* <key> \h* \n
+        [
+        | <value=.single-line-option>
+        | <value=.multi-line-str-option('+++')>
+        ]+
+    }
+
+    token multi-line-str-option($prefix) {
+        \h* $prefix \h* <key> \h* \n
+        # We want no leading lines and no trailing empty lines, but do want
+        # interior empty lines. We eat lines up until we see a "terminator",
+        # which is whitespace followed by *** (section heading) or + (next
+        # option).
+        <.blank-line>*
+        $<value>=[
+            [
+                <!before \s* ['+' || '***' || $]>
+                \N* [\n || $]
+            ]*
+        ]
+        <.blank-line>*
+    }
+
+    token name {
+        '::'? <.name-part> [ '::' <.name-part> ]*
+    }
+
+    token name-part {
+        <.ident> | '..'
+    }
+
+    token key {
+        \w+
+    }
+
+    token blank-line {
+        | \h* \n
+        | \h* '#' \N* \n
+        | \h+ $
+    }
+}

--- a/lib/Agrammon/ModuleParser.pm6
+++ b/lib/Agrammon/ModuleParser.pm6
@@ -1,6 +1,7 @@
 use v6;
+use Agrammon::CommonParser;
 
-grammar Agrammon::ModuleParser {
+grammar Agrammon::ModuleParser does Agrammon::CommonParser {
     token TOP {
         :my $*TAXONOMY = '';
         <.blank-line>*
@@ -9,10 +10,6 @@ grammar Agrammon::ModuleParser {
         || $
         || <.panic('Confused')>
         ]
-    }
-
-    method panic($message) {
-        die "$message near " ~ self.orig.substr(self.pos, 50).perl;
     }
 
     proto token section { * }
@@ -64,65 +61,5 @@ grammar Agrammon::ModuleParser {
         | <.blank-line>
         | <tests=.option-section>
         ]*
-    }
-
-    token option-section {
-        \h* '+' \h* <name> \h* \n
-        [
-        | <.blank-line>
-        | <option=.single-line-option>
-        | <option=.subsection-map>
-        | <option=.multi-line-str-option('++')>
-        ]*
-    }
-
-    token section-heading($title) {
-        \h* '***' \h* $title \h* '***' \h* \n
-    }
-
-    token subsection-map {
-        \h* '++' \h* <key> \h* \n
-        [
-        | <value=.single-line-option>
-        | <value=.multi-line-str-option('+++')>
-        ]+
-    }
-
-    token single-line-option {
-        \h* <key> \h* '=' \h* $<value>=[\N*] [\n || $]
-    }
-
-    token multi-line-str-option($prefix) {
-        \h* $prefix \h* <key> \h* \n
-        # We want no leading lines and no trailing empty lines, but do want
-        # interior empty lines. We eat lines up until we see a "terminator",
-        # which is whitespace followed by *** (section heading) or + (next
-        # option).
-        <.blank-line>*
-        $<value>=[
-            [
-                <!before \s* ['+' || '***' || $]>
-                \N* [\n || $]
-            ]*
-        ]
-        <.blank-line>*
-    }
-
-    token key {
-        \w+
-    }
-
-    token name {
-        '::'? <.name-part> [ '::' <.name-part> ]*
-    }
-
-    token name-part {
-        <.ident> | '..'
-    }
-
-    token blank-line {
-        | \h* \n
-        | \h* '#' \N* \n
-        | \h+ $
     }
 }

--- a/lib/Agrammon/TechnicalBuilder.pm6
+++ b/lib/Agrammon/TechnicalBuilder.pm6
@@ -14,5 +14,4 @@ class Agrammon::TechnicalBuilder {
     method single-line-option($/) {
         make Agrammon::Model::Technical.new( name => ~$<key>, value => ~$<value> );
     }
-
 }

--- a/lib/Agrammon/TechnicalParser.pm6
+++ b/lib/Agrammon/TechnicalParser.pm6
@@ -1,6 +1,8 @@
 use v6;
+use Agrammon::CommonParser;
+use Agrammon::TechnicalBuilder;
 
-grammar Agrammon::TechnicalParser {
+grammar Agrammon::TechnicalParser does Agrammon::CommonParser {
     token TOP {
         <.blank-line>*
         <.section-heading('technical_parameters')>
@@ -8,30 +10,9 @@ grammar Agrammon::TechnicalParser {
         | <parameters=.option-section>
         | <.blank-line>
         ]*
-    }
-
-    token name {
-        <.ident> [ '::' <.ident> ]*
-    }
-
-    token option-section {
-        '+' <name> \h* \n
         [
-        | <.blank-line>
-        | '  ' <option=.single-line-option>
-        ]*
-    }
-
-    token section-heading($title) {
-        \h* '***' \h* $title \h* '***' \h* \n
-    }
-
-    token single-line-option {
-        <key=.ident> \h* '=' \h* $<value>=[\N*] \n
-    }
-
-    token blank-line {
-        | \h* \n
-        | \h* '#' \N* \n
+        || $
+        || <.panic('Confused')>
+        ]
     }
 }


### PR DESCRIPTION
Move common things they both need into CommonParser, using the code
from ModuleParser which is more correct in various ways. This gets us
able to parse some technical configuration files we so far couldn't.

Also adds error handling to resolve #46.