### PR TITLE
Handle comments on single line options

### DIFF
--- a/lib/Agrammon/CommonParser.pm6
+++ b/lib/Agrammon/CommonParser.pm6
@@ -18,7 +18,10 @@ role Agrammon::CommonParser {
     }
 
     token single-line-option {
-        \h* <key> \h* '=' \h* $<value>=[\N*] [\n || $]
+        \h* <key> \h* '=' \h*
+        $<value>=[[<!before \h*'#'>\N]*]
+        \h* ['#'\N*]?
+        [\n || $]
     }
     token subsection-map {
         \h* '++' \h* <key> \h* \n

--- a/t/test-data/CMilk.nhd
+++ b/t/test-data/CMilk.nhd
@@ -43,7 +43,7 @@ Longer description. May span many lines.
 *** technical ***
 
 +standard_milk_yield
-  value = 6500
+  value = 6500 # ignore this comment
   ++units
     en = kg/year
     de = kg/Jahr


### PR DESCRIPTION
So that:

```
foo = 1.5 # was 2.5
```

Does the right thing.