### PR TITLE
Refactor formula list op handling

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -25,6 +25,8 @@
         "Agrammon::Model::Technical": "lib/Agrammon/Model/Technical.pm6",
         "Agrammon::Config": "lib/Agrammon/Config.pm6",
         "Agrammon::Model::Input": "lib/Agrammon/Model/Input.pm6",
+        "Agrammon::Formula::Builtins": "lib/Agrammon/Formula/Builtins.pm6",
+        "Agrammon::Formula::ControlFlow": "lib/Agrammon/Formula/ControlFlow.pm6",
         "Agrammon::Model::Module": "lib/Agrammon/Model/Module.pm6",
         "Agrammon::DB::Role": "lib/Agrammon/DB/Role.pm6",
         "Agrammon::Web::Service": "lib/Agrammon/Web/Service.pm6",

--- a/lib/Agrammon/Environment.pm6
+++ b/lib/Agrammon/Environment.pm6
@@ -1,3 +1,5 @@
+use Agrammon::Formula::Builtins;
+
 class Agrammon::Environment {
     my class Scope {
         has %.variables;
@@ -24,7 +26,7 @@ class Agrammon::Environment {
     has %.technical;
     has %.output;
     has Scope $.scope .= new;
-    has %.builtins;
+    has %.builtins = get-builtins();
 
     method enter-scope(--> Nil) {
         $!scope = Scope.new(outer => $!scope)

--- a/lib/Agrammon/Formula.pm6
+++ b/lib/Agrammon/Formula.pm6
@@ -1,4 +1,5 @@
 use Agrammon::Environment;
+use Agrammon::Formula::ControlFlow;
 use Agrammon::OutputReference;
 
 role Agrammon::Formula {
@@ -22,14 +23,6 @@ role Agrammon::Formula {
 
 role Agrammon::Formula::LValue does Agrammon::Formula {
     # Just a marker role for l-values (things that can be assigned to)
-}
-
-class X::Agrammon::Formula::ReturnException is Exception {
-    has $.payload is default(Nil);
-}
-
-class X::Agrammon::Formula::SucceedException is Exception {
-    has $.payload is default(Nil);
 }
 
 class Agrammon::Formula::StatementList does Agrammon::Formula {
@@ -260,30 +253,6 @@ role Agrammon::Formula::OneExpressionBuiltin does Agrammon::Formula {
     method input-used() { $!expression.input-used }
     method technical-used() { $!expression.technical-used }
     method output-used() { $!expression.output-used }
-}
-
-class Agrammon::Formula::Return does Agrammon::Formula::OneExpressionBuiltin {
-    method evaluate(Agrammon::Environment $env) {
-        die X::Agrammon::Formula::ReturnException.new(
-            payload => $!expression.evaluate($env)
-        );
-    }
-}
-
-class X::Agrammon::Formula::Died is Exception {
-    has $.message;
-}
-
-class Agrammon::Formula::Die does Agrammon::Formula::OneExpressionBuiltin {
-    method evaluate(Agrammon::Environment $env) {
-        die X::Agrammon::Formula::Died.new(message => $!expression.evaluate($env));
-    }
-}
-
-class Agrammon::Formula::Warn does Agrammon::Formula::OneExpressionBuiltin {
-    method evaluate(Agrammon::Environment $env) {
-        warn $!expression.evaluate($env);
-    }
 }
 
 class Agrammon::Formula::Not does Agrammon::Formula::OneExpressionBuiltin {

--- a/lib/Agrammon/Formula/Builder.pm6
+++ b/lib/Agrammon/Formula/Builder.pm6
@@ -200,30 +200,19 @@ class Agrammon::Formula::Builder {
         );
     }
 
+    method term:sym<listop>($/) {
+        make Agrammon::Formula::CallBuiltin.new(
+            name => ~$<ident>,
+            args => $<arg>.map(*.ast)
+        );
+    }
+
     method term:sym<my>($/) {
         make Agrammon::Formula::VarDecl.new(name => ~$<variable>);
     }
 
     method term:sym<variable>($/) {
         make Agrammon::Formula::Var.new(name => ~$<variable>);
-    }
-
-    method term:sym<return>($/) {
-        make Agrammon::Formula::Return.new(
-            expression => $<EXPR> ?? $<EXPR>.ast !! Agrammon::Formula::Nil.new
-        );
-    }
-
-    method term:sym<die>($/) {
-        make Agrammon::Formula::Die.new(
-            expression => $<EXPR>.ast
-        );
-    }
-
-    method term:sym<warn>($/) {
-        make Agrammon::Formula::Warn.new(
-            expression => $<EXPR>.ast
-        );
     }
 
     method term:sym<not>($/) {

--- a/lib/Agrammon/Formula/Builtins.pm6
+++ b/lib/Agrammon/Formula/Builtins.pm6
@@ -1,0 +1,18 @@
+use Agrammon::Formula::ControlFlow;
+
+sub get-builtins is export {
+    return {
+        writeLog => -> %langMessages {
+            dd %langMessages
+        },
+        return => -> $payload = Nil {
+            die X::Agrammon::Formula::ReturnException.new(:$payload);
+        },
+        die => -> *@message {
+            die X::Agrammon::Formula::Died.new(message => @message.join || 'Died');
+        },
+        warn => -> *@message {
+            warn @message.join || 'Warning';
+        }
+    }
+}

--- a/lib/Agrammon/Formula/ControlFlow.pm6
+++ b/lib/Agrammon/Formula/ControlFlow.pm6
@@ -1,0 +1,11 @@
+class X::Agrammon::Formula::ReturnException is Exception {
+    has $.payload is default(Nil);
+}
+
+class X::Agrammon::Formula::SucceedException is Exception {
+    has $.payload is default(Nil);
+}
+
+class X::Agrammon::Formula::Died is Exception {
+    has $.message;
+}

--- a/lib/Agrammon/Formula/Parser.pm6
+++ b/lib/Agrammon/Formula/Parser.pm6
@@ -35,6 +35,7 @@ grammar Agrammon::Formula::Parser {
     }
 
     rule EXPR {
+        {} # Don't LTM-descend into EXPR
         <term> [ <infix> <term> ]*
     }
 
@@ -116,18 +117,6 @@ grammar Agrammon::Formula::Parser {
         '$' <.ident>
     }
 
-    rule term:sym<return> {
-        'return' <EXPR>?
-    }
-
-    rule term:sym<die> {
-        'die' <EXPR>
-    }
-
-    rule term:sym<warn> {
-        'warn' <EXPR>
-    }
-
     rule term:sym<not> {
         'not' <EXPR>
     }
@@ -142,6 +131,16 @@ grammar Agrammon::Formula::Parser {
 
     rule term:sym<uc> {
         'uc' <term>
+    }
+
+    token term:sym<listop> {
+        <!before < not defined lc uc >>
+        <ident>
+        [
+        | \s+ :s '(' <arg=.EXPR>* % [ ',' ] [ ')' || <.panic('Missing closing ) on call')> ]
+        | \s+ :s <arg=.EXPR>* % [ ',' ]
+        | :s <?>
+        ]
     }
 
     rule term:sym<( )> {


### PR DESCRIPTION
So that we now just treat return, die, and warn as built-ins. Add a
cheating writeLog while we're at it. This lets us simplify the formula
evaluator a little too, and will make it easier to add further builtins
in the future, knowing they'll work with all calling syntaxes.