### PR TITLE
Only create result arrays on first module mention

### DIFF
--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -85,7 +85,7 @@ class Agrammon::Model {
                 # recursive walk to set up output arrays and mark things as being run
                 # to elegantly handle the case of no instances.
                 my $*IN-MULTI = True;
-                self!result-arrays(%outputs);
+                self!result-arrays(%outputs, %run-already);
                 for $input.inputs-list-for($tax) -> $multi-input {
                     my %run-already-copy = %run-already;
                     self!run-as-single($multi-input, %technical, %outputs, %run-already-copy);
@@ -142,13 +142,14 @@ class Agrammon::Model {
             }
         }
 
-        method !result-arrays(%outputs --> Nil) {
+        method !result-arrays(%outputs, %run-already --> Nil) {
             my $tax = $!module.taxonomy;
+            return if %run-already{$tax};
             for $!module.output {
                 %outputs{$tax}{.name} = [];
             }
             for @!dependencies -> $dep {
-                $dep!result-arrays(%outputs);
+                $dep!result-arrays(%outputs, %run-already);
             }
         }
 


### PR DESCRIPTION
Otherwise, we can recurse into them in `create-arrays` when a module
that was in one multi-instance tree is an external of a different
multi-instance tree, and thus trash the original data that was already
stored for those modules.