### PR TITLE
Fix `return` to match the Perl 5 syntax

### DIFF
--- a/lib/Agrammon/Formula/Builder.pm6
+++ b/lib/Agrammon/Formula/Builder.pm6
@@ -200,6 +200,13 @@ class Agrammon::Formula::Builder {
         );
     }
 
+    method term:sym<return>($/) {
+        make Agrammon::Formula::CallBuiltin.new(
+            name => 'return',
+            args => $<EXPR> ?? ($<EXPR>.ast) !! ()
+        );
+    }
+
     method term:sym<listop>($/) {
         make Agrammon::Formula::CallBuiltin.new(
             name => ~$<ident>,

--- a/lib/Agrammon/Formula/Parser.pm6
+++ b/lib/Agrammon/Formula/Parser.pm6
@@ -133,8 +133,12 @@ grammar Agrammon::Formula::Parser {
         'uc' <term>
     }
 
+    rule term:sym<return> {
+        'return' <EXPR>?
+    }
+
     token term:sym<listop> {
-        <!before < not defined lc uc >>
+        <!before < not defined lc uc return >>
         <ident>
         [
         | \s+ :s '(' <arg=.EXPR>* % [ ',' ] [ ')' || <.panic('Missing closing ) on call')> ]

--- a/t/formula.t
+++ b/t/formula.t
@@ -467,6 +467,18 @@ subtest {
 }, 'Empty return evalutes to Nil';
 
 subtest {
+    my $f = parse-formula('return (In(agricultural_area) + 2) * 3', 'PlantProduction');
+    ok $f ~~ Agrammon::Formula, 'Get something doing Agrammon::Formula from parse';
+    is-deeply $f.input-used, ('agricultural_area',), 'Correct inputs-used';
+    is-deeply $f.technical-used, (), 'Correct technical-used';
+    is-deeply $f.output-used, (), 'Correct output-used';
+    my $result = $f.evaluate(Agrammon::Environment.new(
+            input => { agricultural_area => 42 }
+            ));
+    is $result, (42 + 2) * 3, 'Correct result from evaluation';
+}, 'The return statement does not parse according to normal function rules';
+
+subtest {
     my $f = parse-formula(q:to/FORMULA/, 'PlantProduction');
         (In(solid_digestate) - Tech(er_solid_digestate)) /
         (In(compost) - Tech(er_compost));


### PR DESCRIPTION
It doesn't behave like a normal function call.