### PR TITLE
Compile all formulas in a single EVAL

### DIFF
--- a/lib/Agrammon/Formula/Compiler.pm6
+++ b/lib/Agrammon/Formula/Compiler.pm6
@@ -7,6 +7,10 @@ sub compile-formula(Agrammon::Formula $formula --> Code) is export {
     return EVAL compile($formula);
 }
 
+sub compile-formula-to-source(Agrammon::Formula $formula --> Str) is export {
+    return compile($formula);
+}
+
 multi compile(Agrammon::Formula::Routine $r) {
     'sub ($env) { ' ~ compile($r.statements) ~ ' }';
 }

--- a/lib/Agrammon/Model/Output.pm6
+++ b/lib/Agrammon/Model/Output.pm6
@@ -7,5 +7,5 @@ class Agrammon::Model::Output {
     has Str $.print;        # XXX Check what type this should really be
     has Str %.units{Str};
     has Agrammon::Formula $.formula;
-    has &.compiled-formula;
+    has &.compiled-formula is rw;
 }

--- a/lib/Agrammon/ModuleBuilder.pm6
+++ b/lib/Agrammon/ModuleBuilder.pm6
@@ -1,5 +1,4 @@
 use v6;
-use Agrammon::Formula::Compiler;
 use Agrammon::Formula::Parser;
 use Agrammon::Model::External;
 use Agrammon::Model::Input;
@@ -45,7 +44,6 @@ class Agrammon::ModuleBuilder {
             with %output-props<formula> <-> $formula {
                 with $*TAXONOMY -> $taxonomy {
                     $formula = parse-formula($formula, $taxonomy);
-                    %output-props<compiled-formula> = compile-formula($formula);
                     CATCH {
                         default {
                             die "Error compiling formula for output '%output-props<name>' " ~


### PR DESCRIPTION
Knocks off the overhead of all the individual EVAL calls, which turns
out to be pretty significant. This gets model loading of the hr-inclNOx
down to 75% of the time it took before this change.