### PR TITLE
Fix a hang in the outputs test

### DIFF
--- a/lib/Agrammon/Outputs.pm6
+++ b/lib/Agrammon/Outputs.pm6
@@ -139,6 +139,7 @@ class Agrammon::Outputs does Agrammon::Outputs::SingleOutputStorage {
             .return with %!instances{$module.substr(0, $start)};
             $start = $module.rindex('::', $start - 1);
         }
+        Nil
     }
 
     method get-outputs-hash() {

--- a/lib/Agrammon/Outputs.pm6
+++ b/lib/Agrammon/Outputs.pm6
@@ -106,14 +106,12 @@ class Agrammon::Outputs does Agrammon::Outputs::SingleOutputStorage {
     }
 
     method !bad-output(Str $module, Str $name) {
-        if %!outputs{$module}{$name}:exists {
-            return %!outputs{$module}{$name};
-        }
-        orwith self.find-instances($module) {
-            .get-output($module, $name) with .values.first; # Will throw if symbol fully unknown
+        with self.find-instances($module) {
             die X::Agrammon::Outputs::IsMultiInstance.new(:$module, :$name);
         }
-        die X::Agrammon::Outputs::Unset.new(:$module, :$name);
+        else {
+            die X::Agrammon::Outputs::Unset.new(:$module, :$name);
+        }
     }
 
     method get-sum(Str $module, Str $name) {

--- a/t/outputs.t
+++ b/t/outputs.t
@@ -74,23 +74,26 @@ subtest 'Multi-instance outputs' => {
         module => 'Visible::From::All',
         name => 'sym';
 
-    is-deeply $outputs.get-outputs-hash(),
-        {
-            'Visible::From::All' => { sym => 99 },
-             'Multi::Instance' => [
-                 'Instance 1' => {
-                     'Multi::Instance::Foo' => { bar => 10 },
-                     'Multi::Instance::Bar' => { baz => 20 },
-                     'Multi::Instance' => { 'wat' => 30 }
-                 },
-                 'Instance 2' => {
-                     'Multi::Instance::Foo' => { bar => 50 },
-                     'Multi::Instance::Bar' => { baz => 60 },
-                     'Multi::Instance' => { 'wat' => 70 }
-                 }
-             ]
-        },
-        'Getting multi-instance outputs works';
+    given $outputs.get-outputs-hash() -> %outputs {
+        %outputs<Multi::Instance> = [%outputs<Multi::Instance>.sort(*.key)];
+        is-deeply %outputs,
+            {
+                'Visible::From::All' => { sym => 99 },
+                 'Multi::Instance' => [
+                     'Instance 1' => {
+                         'Multi::Instance::Foo' => { bar => 10 },
+                         'Multi::Instance::Bar' => { baz => 20 },
+                         'Multi::Instance' => { 'wat' => 30 }
+                     },
+                     'Instance 2' => {
+                         'Multi::Instance::Foo' => { bar => 50 },
+                         'Multi::Instance::Bar' => { baz => 60 },
+                         'Multi::Instance' => { 'wat' => 70 }
+                     }
+                 ]
+            },
+            'Getting multi-instance outputs works';
+    }
 }
 
 done-testing;


### PR DESCRIPTION
Various fixes to make the test run reliably; it could hang due to hash randomization.