### PR TITLE
Add end result tests for complex model run

### DIFF
--- a/t/run-complex-model.t
+++ b/t/run-complex-model.t
@@ -20,18 +20,26 @@ lives-ok
     'Parsed technical file';
 isa-ok $params, Agrammon::Model::Parameters, 'Correct type for technical data';
 
-my $output;
+my %output;
 lives-ok
     {
-        $output = $model.run(
+        %output = $model.run(
             input => @datasets[0],
             technical => %($params.technical.map(-> %module {
                 %module.keys[0] => %(%module.values[0].map({ .name => .value }))
             }))
-        )
+        ).get-outputs-hash()
     },
     'Successfully executed model';
 
-# TODO: Test the output is correct
+is %output<Total><nh3_ntotal>, <1034973404862461426773/2623437500000000000>,
+            'Correct nh3_ntotal result';
+is %output<Total><nh3_nanimalproduction>, <764444529862461426773/2623437500000000000>,
+            'Correct nh3_nanimalproduction result';
+
+todo "Detailed tests for intermediate results", 1;
+subtest "Intermediate results" => {
+    flunk("Intermediate results ok");
+}
 
 done-testing;


### PR DESCRIPTION
- Test the two "final" numbers of the complex model run
- Add TODO for additional intermediate result tests
We want to be sure that any changes to the code will not change the simulation results unexpectedly.