### PR TITLE
Give informative warning on missing filter value

### DIFF
--- a/lib/Agrammon/Model/FilterSet.pm6
+++ b/lib/Agrammon/Model/FilterSet.pm6
@@ -29,7 +29,13 @@ class Agrammon::Model::FilterSet {
     #| Build mapping of filter keys to the matching values for the instance in question.
     method filters-for($multi-input --> Hash) {
         hash @!filters.map: -> Filter $filter {
-            $filter.filter-key => $multi-input.input-hash-for($filter.taxonomy){$filter.input-name}
+            with $multi-input.input-hash-for($filter.taxonomy){$filter.input-name} {
+                $filter.filter-key => $_
+            }
+            else {
+                warn "Missing filter value for '$filter.input-name()' in $filter.taxonomy() on instance '$multi-input.instance-id()'";
+                Empty
+            }
         }
     }
 }


### PR DESCRIPTION
Rather than letting it warn in the middle of some calculation later on.
Also completely disregard that filter key/value pair when constructing
the filter hash.