### PR TITLE
Provide filterGroup built-in to make filter groups

### DIFF
--- a/t/model-with-filters.t
+++ b/t/model-with-filters.t
@@ -92,6 +92,23 @@ subtest 'Running the model produces output instances with filters' => {
         }
     }
 
+    subtest 'filterGroup builtin' => {
+        given $output.get-output('Livestock', 'factors') -> $factor {
+            isa-ok $factor, Agrammon::Outputs::FilterGroupCollection,
+                    'filterGroup builtin will produce a filter group collection';
+            my @results-by-group = $factor.results-by-filter-group;
+            dd @results-by-group;
+            given @results-by-group.grep(*.key eqv { "Livestock::Pig::Excretion::animalcategory" => "boars" }) {
+                is .elems, 1, 'Found filter group value for boars';
+                is .[0].value, 0.75, 'Correct value for boars';
+            }
+            given @results-by-group.grep(*.key eqv { "Livestock::Pig::Excretion::animalcategory" => "dry_sows" }) {
+                is .elems, 1, 'Found filter group value for dry sows';
+                is .[0].value, 0.5, 'Correct value for dry sows';
+            }
+        }
+    }
+
     subtest 'Final outputs still correct even with filter groups in effect' => {
         is $output.get-output('Total', 'nh3_ntotal'),
                 455.8311423399035e0,

--- a/t/test-data/Models/with-filters/Livestock.nhd
+++ b/t/test-data/Models/with-filters/Livestock.nhd
@@ -161,6 +161,22 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
     Sum(n_sol_excretion,Livestock::RoughageConsuming::Excretion) P+
     Sum(n_sol_excretion,Livestock::Poultry::Excretion);
 
++factors
+  format= %.0f
+  print = Factors
+  ++labels
+    en = Factors
+    de = Faktoren
+    fr = Facteurs
+  ++description
+    Factor
+  ++formula
+    filterGroup('Livestock::Pig::Excretion',
+        { animalcategory => 'boars' }, 0.75,
+        { animalcategory => 'dry_sows' }, 0.5,
+        { animalcategory => 'nursing_sows' }, 0.75,
+        { animalcategory => 'weaned_piglets_up_to_25kg' }, 0.25)
+
 +n_into_storage
   format= %.0f
   print = FluxSummaryLivestock


### PR DESCRIPTION
So that they can be manually constructed in order to provide, for
example, coefficients that can be used to scale other filter groups by.