### PR TITLE
Fix calculation of nh3 loss in pig housing

### DIFF
--- a/t/run-complex-model-with-filters.t
+++ b/t/run-complex-model-with-filters.t
@@ -12,11 +12,11 @@ use Agrammon::TechnicalParser;
 my $temp-dir = $*TMPDIR.add('agrammon_testing');
 
 #| Expected results
-my $nh3-ntotal = 3172.222;
-my $nh3-nanimalproduction = 3150.022;
-my $nh3-napplication = 1347.3;
-my $n-into-application = 7535.775;
-my $tan-into-application = 3184.176;
+my $nh3-ntotal = 3166.899;
+my $nh3-nanimalproduction = 3144.699;
+my $nh3-napplication = 1347.296;
+my $n-into-application = 7534.951;
+my $tan-into-application = 3186.255;
 
 my $filename = 'hr-inclNOxExtendedWithFilters-model-input.csv';
 my $fh = open $*PROGRAM.parent.add("test-data/$filename");

--- a/t/test-data/Models/hr-inclNOxExtended/Livestock/FatteningPigs/Housing.nhd
+++ b/t/test-data/Models/hr-inclNOxExtended/Livestock/FatteningPigs/Housing.nhd
@@ -75,12 +75,14 @@ taxonomy = Livestock::FatteningPigs::Housing
    Val(tan_excretion,Excretion) 
     * Val(er_housing,Housing::Type) 
     * (
-         (1 - Val(c_air_scrubber,Housing::AirScrubber)*Val(share_outdoor,Housing::Type) )
-         * (1 - Val(c_UNECE_housing_task,Housing::MitigationOptions)*Val(share_outdoor,Housing::Type) )
-         * (1 - Val(c_housing_slurry_channel,Housing::MitigationOptions)*Val(share_outdoor,Housing::Type) )
-         * (1 - Val(c_housing_climate,Housing::MitigationOptions)*Val(share_outdoor,Housing::Type) )
-         * (1 - Val(c_housing_air,Housing::MitigationOptions)*Val(share_outdoor,Housing::Type))  -
-          Val(c_exercise_place,Housing::Type)
+      Val(share_outdoor,Housing::Type) *
+         (1 - Val(c_air_scrubber,Housing::AirScrubber) )
+         * (1 - Val(c_UNECE_housing_task,Housing::MitigationOptions) )
+         * (1 - Val(c_housing_slurry_channel,Housing::MitigationOptions) )
+         * (1 - Val(c_housing_climate,Housing::MitigationOptions) )
+         * (1 - Val(c_housing_air,Housing::MitigationOptions))  +
+      (1 - Val(share_outdoor,Housing::Type)) * 
+          (1 - Val(c_exercise_place,Housing::Type))
        )
     * Val(c_free_factor_housing, Housing::CFreeFactor) ; 
 	   
@@ -97,12 +99,12 @@ taxonomy = Livestock::FatteningPigs::Housing
    Val(tan_excretion,Excretion) 
     * Val(er_housing,Housing::Type) 
     * Val(c_air_scrubber,Housing::AirScrubber) 
+    * Val(share_outdoor,Housing::Type)
     * (
-         (1 - Val(c_UNECE_housing_task,Housing::MitigationOptions)*Val(share_outdoor,Housing::Type) )
-         * (1 - Val(c_housing_slurry_channel,Housing::MitigationOptions)*Val(share_outdoor,Housing::Type ) )
-         * (1 - Val(c_housing_climate,Housing::MitigationOptions)*Val(share_outdoor,Housing::Type ) )
-         * (1 - Val(c_housing_air,Housing::MitigationOptions)*Val(share_outdoor,Housing::Type) )  -
-          Val(c_exercise_place,Housing::Type)
+         (1 - Val(c_UNECE_housing_task,Housing::MitigationOptions) )
+         * (1 - Val(c_housing_slurry_channel,Housing::MitigationOptions) )
+         * (1 - Val(c_housing_climate,Housing::MitigationOptions) )
+         * (1 - Val(c_housing_air,Housing::MitigationOptions) )
       )
     * Val(c_free_factor_housing, Housing::CFreeFactor) ;  
 
@@ -120,7 +122,7 @@ taxonomy = Livestock::FatteningPigs::Housing
      if(Val(housing_type,Housing::Type) eq 'Outdoor'){
         0
      }else {
-     	   if(Val(air_scrubber,Housing::AirScrubber) eq 'acid'){
+     	   if(Val(air_scrubber,Housing::AirScrubber) eq 'biotrickling'){
 	   Out(n_into_housing) - Out(nh3_nhousing) - Out(n_housing_filter)
      	   }else{
 	   Out(n_into_housing) - Out(nh3_nhousing)
@@ -139,7 +141,7 @@ taxonomy = Livestock::FatteningPigs::Housing
     if(Val(housing_type,Housing::Type) eq 'Outdoor'){
         0
     }else {
-     	   if(Val(air_scrubber,Housing::AirScrubber) eq 'acid'){
+     	   if(Val(air_scrubber,Housing::AirScrubber) eq 'biotrickling'){
 	   Out(tan_into_housing) - Out(nh3_nhousing) - Out(n_housing_filter)
      	   }else{
     	   Out(tan_into_housing) - Out(nh3_nhousing)

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/FatteningPigs/Housing.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/FatteningPigs/Housing.nhd
@@ -61,6 +61,17 @@ taxonomy = Livestock::FatteningPigs::Housing
   ++formula
     Val(tan_excretion, Excretion) - Val(tan_into_grazing, Grazing);
 
++tan_into_housing_indoor
+  print = 7
+  ++units
+     en = kg N/year
+     de = kg N/Jahr
+     fr = kg N/an 
+  ++description
+    Annual N flux as TAN into the house.
+  ++formula
+    Out(tan_into_housing) * Val(share_indoor, Housing::Type);
+
 +nh3_nhousing
   print = 5b
   ++units
@@ -71,13 +82,18 @@ taxonomy = Livestock::FatteningPigs::Housing
     Annual NH3 emission from fattening pig housing systems.
   ++formula
     # change effect of mitigation strategies for indoor/outdoor? -> check with Thomas
-    Val(tan_excretion, Excretion) * 
+    Out(tan_into_housing) * 
     Val(er_housing, Housing::Type) * 
     Val(c_free_factor_housing, Housing::CFreeFactor) *
-    # indoor reductions
-    (1 - Val(red_air_scrubber, Housing::AirScrubber) * Val(share_indoor, Housing::Type)) * 
-    (1 - Val(red_housing_floor, Housing::MitigationOptions) * Val(share_indoor, Housing::Type)) * 
-    (1 - Val(red_housing_air, Housing::MitigationOptions) * Val(share_indoor, Housing::Type));
+    (
+      # indoor part + mitigation
+      Val(share_indoor, Housing::Type) * 
+      (1 - Val(red_air_scrubber, Housing::AirScrubber)) * 
+      (1 - Val(red_housing_floor, Housing::MitigationOptions)) * 
+      (1 - Val(red_housing_air, Housing::MitigationOptions)) +
+      # outdoor part + mitigation
+      (1 - Val(share_indoor, Housing::Type))
+    );
 
 +n_air_scrubber
   print = 5b
@@ -89,14 +105,15 @@ taxonomy = Livestock::FatteningPigs::Housing
     Annual N of NH3 emission remaining in air scrubber from pig housing systems.
   ++formula
     # change effect of mitigation strategies for indoor/outdoor? -> check with Thomas
+    # reduction efficiency of air scrubber
+    Val(red_air_scrubber, Housing::AirScrubber) *
+    # multiplied with indoor loss without air scrubber mitigation
     Val(tan_excretion,Excretion) * 
-    Val(er_housing,Housing::Type) * 
-    Val(c_free_factor_housing, Housing::CFreeFactor) * 
-    # indoor reductions
-    (1 - Val(red_housing_floor,Housing::MitigationOptions)*Val(share_indoor,Housing::Type)) *
-    (1 - Val(red_housing_air,Housing::MitigationOptions)*Val(share_indoor,Housing::Type)) *
-    Val(red_air_scrubber,Housing::AirScrubber);  
-
+    Val(er_housing, Housing::Type) * 
+    Val(c_free_factor_housing, Housing::CFreeFactor) *
+    Val(share_indoor, Housing::Type) *  
+    (1 - Val(red_housing_floor, Housing::MitigationOptions)) *
+    (1 - Val(red_housing_air, Housing::MitigationOptions));  
 
 +n_outhousing
   print = 7

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/FatteningPigs/Housing.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/FatteningPigs/Housing.nhd
@@ -70,15 +70,16 @@ taxonomy = Livestock::FatteningPigs::Housing
   ++description
     Annual NH3 emission from fattening pig housing systems.
   ++formula
+    # change effect of mitigation strategies for indoor/outdoor? -> check with Thomas
     Val(tan_excretion, Excretion) * 
     Val(er_housing, Housing::Type) * 
     Val(c_free_factor_housing, Housing::CFreeFactor) *
     # indoor reductions
-    (1 - Val(red_air_scrubber, Housing::AirScrubber) * Val(share_indoor, Housing::Type) ) * 
-    (1 - Val(red_housing_floor, Housing::MitigationOptions) * Val(share_indoor, Housing::Type) ) * 
+    (1 - Val(red_air_scrubber, Housing::AirScrubber) * Val(share_indoor, Housing::Type)) * 
+    (1 - Val(red_housing_floor, Housing::MitigationOptions) * Val(share_indoor, Housing::Type)) * 
     (1 - Val(red_housing_air, Housing::MitigationOptions) * Val(share_indoor, Housing::Type));
 
-+n_housing_filter
++n_air_scrubber
   print = 5b
   ++units
      en = kg N/year
@@ -87,14 +88,14 @@ taxonomy = Livestock::FatteningPigs::Housing
   ++description
     Annual N of NH3 emission remaining in air scrubber from pig housing systems.
   ++formula
-   Val(tan_excretion,Excretion) 
-    * Val(er_housing,Housing::Type) 
-    * Val(red_air_scrubber,Housing::AirScrubber) 
-    * (
-         (1 - Val(red_housing_floor,Housing::MitigationOptions)*Val(share_indoor,Housing::Type) )
-         * (1 - Val(red_housing_air,Housing::MitigationOptions)*Val(share_indoor,Housing::Type))
-      )
-    * Val(c_free_factor_housing, Housing::CFreeFactor) ;  
+    # change effect of mitigation strategies for indoor/outdoor? -> check with Thomas
+    Val(tan_excretion,Excretion) * 
+    Val(er_housing,Housing::Type) * 
+    Val(c_free_factor_housing, Housing::CFreeFactor) * 
+    # indoor reductions
+    (1 - Val(red_housing_floor,Housing::MitigationOptions)*Val(share_indoor,Housing::Type)) *
+    (1 - Val(red_housing_air,Housing::MitigationOptions)*Val(share_indoor,Housing::Type)) *
+    Val(red_air_scrubber,Housing::AirScrubber);  
 
 
 +n_outhousing
@@ -107,15 +108,18 @@ taxonomy = Livestock::FatteningPigs::Housing
     Annual N flux out of the housing including N remained in biotrickling filter,
     (without remains in acid filter).
   ++formula
-     if(Val(housing_type,Housing::Type) eq 'Outdoor'){
-        0
-     }else {
-     	   if(Val(air_scrubber,Housing::AirScrubber) eq 'acid'){
-	   Out(n_into_housing) - Out(nh3_nhousing) - Out(n_housing_filter)
-     	   }else{
-	   Out(n_into_housing) - Out(nh3_nhousing)
-	   };
-     };
+    # change n/tan into storage/application from air scrubber types? -> check with Thomas
+    if ( Val(housing_type,Housing::Type) eq 'Outdoor' ) {
+      0;
+    } else {
+      if ( Val(air_scrubber,Housing::AirScrubber) eq 'biotrickling' ) {
+        # n in biotrickling vanishes
+        Out(n_into_housing) - Out(nh3_nhousing) - Out(n_air_scrubber);
+      } else {
+        # n in acid scrubber adds 100% to flux into storage
+        Out(n_into_housing) - Out(nh3_nhousing);
+      }
+    }
 
 +tan_outhousing
   print = 9
@@ -126,15 +130,18 @@ taxonomy = Livestock::FatteningPigs::Housing
   ++description
     Annual N flux as TAN out of the housing indcluding N remained in biotrickling filter.
   ++formula
-    if(Val(housing_type,Housing::Type) eq 'Outdoor'){
-        0
-    }else {
-     	   if(Val(air_scrubber,Housing::AirScrubber) eq 'acid'){
-	   Out(tan_into_housing) - Out(nh3_nhousing) - Out(n_housing_filter)
-     	   }else{
-    	   Out(tan_into_housing) - Out(nh3_nhousing)
-	   };
-    };
+    # change n/tan into storage/application from air scrubber types? -> check with Thomas
+    if ( Val(housing_type,Housing::Type) eq 'Outdoor' ) {
+      0;
+    } else {
+      if ( Val(air_scrubber,Housing::AirScrubber) eq 'biotrickling' ) {
+        # n in biotrickling vanishes
+        Out(tan_into_housing) - Out(nh3_nhousing) - Out(n_air_scrubber);
+      } else {
+        # n in acid scrubber adds 100% to flux into storage
+        Out(tan_into_housing) - Out(nh3_nhousing);
+      }
+    }
 
 +share_tan_out
   print = 8


### PR DESCRIPTION
For both model versions 'hr-inclNOxExtended' and 'hr-inclNOxExtendedWithFilters':
- Fix n/tan out housing to include correct air scrubber remains 
- Fix wrong aggregated effect of mitigation strategies

and adjust expected values accordingly