### PR TITLE
Fix calculation of NH3 loss in other pig housing

### DIFF
--- a/t/run-complex-model-with-filters.t
+++ b/t/run-complex-model-with-filters.t
@@ -12,11 +12,11 @@ use Agrammon::TechnicalParser;
 my $temp-dir = $*TMPDIR.add('agrammon_testing');
 
 #| Expected results
-my $nh3-ntotal = 3166.899;
-my $nh3-nanimalproduction = 3144.699;
-my $nh3-napplication = 1347.296;
-my $n-into-application = 7534.951;
-my $tan-into-application = 3186.255;
+my $nh3-ntotal = 3183.706;
+my $nh3-nanimalproduction = 3161.506;
+my $nh3-napplication = 1356.284;
+my $n-into-application = 7560.222;
+my $tan-into-application = 3211.526;
 
 my $filename = 'hr-inclNOxExtendedWithFilters-model-input.csv';
 my $fh = open $*PROGRAM.parent.add("test-data/$filename");

--- a/t/test-data/Models/hr-inclNOxExtended/Livestock/Pig/Housing.nhd
+++ b/t/test-data/Models/hr-inclNOxExtended/Livestock/Pig/Housing.nhd
@@ -73,14 +73,16 @@ taxonomy = Livestock::Pig::Housing
     Annual NH3 emission from pig housing systems.
   ++formula
    Val(tan_excretion, Excretion) 
-    * Val(er_housing, Housing::Type) 
+    * Val(er_housing, Housing::Type)
     * (
-         (1 - Val(c_air_scrubber, Housing::AirScrubber)*Val(share_outdoor, Housing::Type) )
-         * (1 - Val(c_UNECE_housing_task, Housing::MitigationOptions)*Val(share_outdoor, Housing::Type) )
-         * (1 - Val(c_housing_slurry_channel, Housing::MitigationOptions)*Val(share_outdoor, Housing::Type ) )
-         * (1 - Val(c_housing_climate, Housing::MitigationOptions)*Val(share_outdoor, Housing::Type ) )
-         * (1 - Val(c_housing_air, Housing::MitigationOptions)*Val(share_outdoor, Housing::Type))  -
-          Val(c_exercise_place, Housing::Type)
+      Val(share_outdoor, Housing::Type)*
+         (1 - Val(c_air_scrubber, Housing::AirScrubber) )
+         * (1 - Val(c_UNECE_housing_task, Housing::MitigationOptions) )
+         * (1 - Val(c_housing_slurry_channel, Housing::MitigationOptions) )
+         * (1 - Val(c_housing_climate, Housing::MitigationOptions) )
+         * (1 - Val(c_housing_air, Housing::MitigationOptions))  +
+         (1 - Val(share_outdoor, Housing::Type)) *
+          (1 - Val(c_exercise_place, Housing::Type))
        )
     * Val(c_free_factor_housing, Housing::CFreeFactor) ; 
 	   
@@ -96,13 +98,13 @@ taxonomy = Livestock::Pig::Housing
   ++formula
    Val(tan_excretion, Excretion) 
     * Val(er_housing, Housing::Type) 
-    * Val(c_air_scrubber, Housing::AirScrubber) 
+    * Val(c_air_scrubber, Housing::AirScrubber)
+    *Val(share_outdoor, Housing::Type) 
     * (
-         (1 - Val(c_UNECE_housing_task, Housing::MitigationOptions)*Val(share_outdoor, Housing::Type) )
-         * (1 - Val(c_housing_slurry_channel, Housing::MitigationOptions)*Val(share_outdoor, Housing::Type ) )
-         * (1 - Val(c_housing_climate, Housing::MitigationOptions)*Val(share_outdoor, Housing::Type ) )
-         * (1 - Val(c_housing_air, Housing::MitigationOptions)*Val(share_outdoor, Housing::Type))  -
-          Val(c_exercise_place, Housing::Type)
+         (1 - Val(c_UNECE_housing_task, Housing::MitigationOptions) )
+         * (1 - Val(c_housing_slurry_channel, Housing::MitigationOptions) )
+         * (1 - Val(c_housing_climate, Housing::MitigationOptions) )
+         * (1 - Val(c_housing_air, Housing::MitigationOptions))
        ); 
 
 
@@ -118,7 +120,7 @@ taxonomy = Livestock::Pig::Housing
      if(Val(housing_type, Housing::Type) eq 'Outdoor'){
         0
      }else {
-     	   if(Val(air_scrubber, Housing::AirScrubber) eq 'acid'){
+     	   if(Val(air_scrubber, Housing::AirScrubber) eq 'biotrickling'){
 	   Out(n_into_housing) - Out(nh3_nhousing) - Out(n_housing_filter)
      	   }else{
 	   Out(n_into_housing) - Out(nh3_nhousing)
@@ -138,7 +140,7 @@ taxonomy = Livestock::Pig::Housing
     if(Val(housing_type, Housing::Type) eq 'Outdoor'){
         0
     }else {
-     	   if(Val(air_scrubber, Housing::AirScrubber) eq 'acid'){
+     	   if(Val(air_scrubber, Housing::AirScrubber) eq 'biotrickling'){
 	   Out(tan_into_housing) - Out(nh3_nhousing) - Out(n_housing_filter)
      	   }else{
     	   Out(tan_into_housing) - Out(nh3_nhousing)

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig/Housing.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig/Housing.nhd
@@ -72,35 +72,39 @@ taxonomy = Livestock::Pig::Housing
   ++description
     Annual NH3 emission from pig housing systems.
   ++formula
-   Val(tan_excretion, Excretion) 
-    * Val(er_housing, Housing::Type) 
-    * (
-       (1 - Val(c_air_scrubber, Housing::AirScrubber) * Val(share_outdoor, Housing::Type) )
-       * (1 - Val(c_UNECE_housing_task, Housing::MitigationOptions) * Val(share_outdoor, Housing::Type) )
-       * (1 - Val(c_housing_slurry_channel, Housing::MitigationOptions) * Val(share_outdoor, Housing::Type) )
-       * (1 - Val(c_housing_air, Housing::MitigationOptions) * Val(share_outdoor, Housing::Type))
-        )
-    * Val(c_free_factor_housing, Housing::CFreeFactor) ; 
-	   
+    # change effect of mitigation strategies for indoor/outdoor? -> check with Thomas
+    Out(tan_into_housing) * 
+    Val(er_housing, Housing::Type) * 
+    Val(c_free_factor_housing, Housing::CFreeFactor) *
+    (
+      # indoor part + mitigation
+      Val(share_indoor, Housing::Type) * 
+      (1 - Val(red_air_scrubber, Housing::AirScrubber)) * 
+      (1 - Val(red_housing_floor, Housing::MitigationOptions)) * 
+      (1 - Val(red_housing_air, Housing::MitigationOptions)) +
+      # outdoor part + mitigation
+      (1 - Val(share_indoor, Housing::Type))
+    );
 
-+n_housing_filter
++n_air_scrubber
   print = 5b
   ++units
      en = kg N/year
      de = kg N/Jahr
-     fr = kg N/an	
+     fr = kg N/an 
   ++description
     Annual N of NH3 emission remaining in air scrubber from pig housing systems.
   ++formula
-   Val(tan_excretion, Excretion) 
-    * Val(er_housing, Housing::Type) 
-    * Val(c_air_scrubber, Housing::AirScrubber) 
-    * (
-         (1 - Val(c_UNECE_housing_task, Housing::MitigationOptions)*Val(share_outdoor, Housing::Type) )
-         * (1 - Val(c_housing_slurry_channel, Housing::MitigationOptions)*Val(share_outdoor, Housing::Type ) )
-         * (1 - Val(c_housing_air, Housing::MitigationOptions)*Val(share_outdoor, Housing::Type))
-       ); 
-
+    # change effect of mitigation strategies for indoor/outdoor? -> check with Thomas
+    # reduction efficiency of air scrubber
+    Val(red_air_scrubber, Housing::AirScrubber) *
+    # multiplied with indoor loss without air scrubber mitigation
+    Val(tan_excretion,Excretion) * 
+    Val(er_housing, Housing::Type) * 
+    Val(c_free_factor_housing, Housing::CFreeFactor) *
+    Val(share_indoor, Housing::Type) *  
+    (1 - Val(red_housing_floor, Housing::MitigationOptions)) *
+    (1 - Val(red_housing_air, Housing::MitigationOptions));  
 
 +n_outhousing
   print = 7
@@ -115,7 +119,7 @@ taxonomy = Livestock::Pig::Housing
         0
      }else {
      	   if(Val(air_scrubber, Housing::AirScrubber) eq 'acid'){
-	   Out(n_into_housing) - Out(nh3_nhousing) - Out(n_housing_filter)
+	   Out(n_into_housing) - Out(nh3_nhousing) - Out(n_air_scrubber)
      	   }else{
 	   Out(n_into_housing) - Out(nh3_nhousing)
 	   };
@@ -135,7 +139,7 @@ taxonomy = Livestock::Pig::Housing
         0
     }else {
      	   if(Val(air_scrubber, Housing::AirScrubber) eq 'acid'){
-	   Out(tan_into_housing) - Out(nh3_nhousing) - Out(n_housing_filter)
+	   Out(tan_into_housing) - Out(nh3_nhousing) - Out(n_air_scrubber)
      	   }else{
     	   Out(tan_into_housing) - Out(nh3_nhousing)
 	   };

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig/Housing.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig/Housing.nhd
@@ -118,7 +118,7 @@ taxonomy = Livestock::Pig::Housing
      if(Val(housing_type, Housing::Type) eq 'Outdoor'){
         0
      }else {
-     	   if(Val(air_scrubber, Housing::AirScrubber) eq 'acid'){
+     	   if(Val(air_scrubber, Housing::AirScrubber) eq 'biotrickling'){
 	   Out(n_into_housing) - Out(nh3_nhousing) - Out(n_air_scrubber)
      	   }else{
 	   Out(n_into_housing) - Out(nh3_nhousing)
@@ -138,7 +138,7 @@ taxonomy = Livestock::Pig::Housing
     if(Val(housing_type, Housing::Type) eq 'Outdoor'){
         0
     }else {
-     	   if(Val(air_scrubber, Housing::AirScrubber) eq 'acid'){
+     	   if(Val(air_scrubber, Housing::AirScrubber) eq 'biotrickling'){
 	   Out(tan_into_housing) - Out(nh3_nhousing) - Out(n_air_scrubber)
      	   }else{
     	   Out(tan_into_housing) - Out(nh3_nhousing)

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig/Housing/AirScrubber.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig/Housing/AirScrubber.nhd
@@ -82,7 +82,7 @@ UNECE 2007. Guidance document on control techniques for preventing and abating e
   ++formula 
     In(air_scrubber);
 
-+c_air_scrubber
++red_air_scrubber
   print = 15
   ++units  
     en = -

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig/Housing/MitigationOptions.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig/Housing/MitigationOptions.nhd
@@ -329,74 +329,93 @@ UNECE 2007. Guidance document on control techniques for preventing and abating e
 
 *** output ***
 
-+c_UNECE_housing_task
++red_housing_floor_SHL
   print = 15
   ++units 
     en = -
   ++description
     Reduction factor for the emission due to UNECE housing systems tasks for fully and partly slatted floors.
-  ++formula 
-    return 0 unless defined In(mitigation_housing_floor);
-    if (In(mitigation_housing_floor) eq "with_scraper_concrete_slats"){
-       return Tech(red_PSF_with_scraper_concrete_slats);
-    }  
-    elsif(In(mitigation_housing_floor) eq "with_flush_channels_no_areation"){
-       return  Tech(red_PSF_with_flush_channels_no_areation);
-    } 
-    elsif(In(mitigation_housing_floor) eq "with_flush_channels_areation"){
-       return Tech(red_PSF_with_flush_channels_areation);
-    } 
-    elsif(In(mitigation_housing_floor) eq "with_flush_gutters_tubes_no_areation"){
-       return Tech(red_PSF_with_flush_gutters_tubes_no_areation);
-    } 
-    elsif(In(mitigation_housing_floor) eq "with_flush_gutters_tubes_areation"){
-       return Tech(red_PSF_with_flush_gutters_tubes_areation);
-    } 
-    elsif(In(mitigation_housing_floor) eq "with_channels_slanted_walls_concrete_slats"){
-       return Tech(red_PSF_with_channels_slanted_walls_concrete_slats);
-    } 
-    elsif(In(mitigation_housing_floor) eq "with_channel_slanted_walls_metal_slats"){
-       return Tech(red_PSF_with_channel_slanted_walls_metal_slats);
-    } 
-    elsif(In(mitigation_housing_floor) eq "with_scraper_metal_slats"){
-       return Tech(red_PSF_with_scraper_metal_slats);
-    } 
-    elsif(In(mitigation_housing_floor) eq "none"){
-       return 0;
-    };
+  ++formula
+    given ( In(mitigation_housing_floor) ) {
+      when "with_scraper_concrete_slats" {
+        Tech(red_PSF_with_scraper_concrete_slats);
+      }  
+      when "with_flush_channels_no_areation" {
+        Tech(red_PSF_with_flush_channels_no_areation);
+      } 
+      when "with_flush_channels_areation" {
+        Tech(red_PSF_with_flush_channels_areation);
+      } 
+      when "with_flush_gutters_tubes_no_areation" {
+        Tech(red_PSF_with_flush_gutters_tubes_no_areation);
+      } 
+      when "with_flush_gutters_tubes_areation" {
+        Tech(red_PSF_with_flush_gutters_tubes_areation);
+      } 
+      when "with_channels_slanted_walls_concrete_slats" {
+        Tech(red_PSF_with_channels_slanted_walls_concrete_slats);
+      } 
+      when "with_channel_slanted_walls_metal_slats" {
+        Tech(red_PSF_with_channel_slanted_walls_metal_slats);
+      } 
+      when "with_scraper_metal_slats" {
+        Tech(red_PSF_with_scraper_metal_slats);
+      } 
+      when "none" {
+        0;
+      }
+      default {
+        # Warning falls not defined mitigation_housing_floor_LU
+        0;
+      }
+    }
 
-+c_housing_slurry_channel
++red_housing_floor_LU
   print = 15
   ++units 
     en = -
   ++description
     Reduction factor for the emission due to housing systems tasks.
   ++formula 
-      return 0 unless defined In(mitigation_housing_floor_LU);
-    if (In(mitigation_housing_floor_LU) eq "with_scraper_concrete_slats"){
-       return Tech(red_PSF_with_scraper_concrete_slats);
-    }  
-    elsif(In(mitigation_housing_floor_LU) eq "with_flush_channels_no_areation"){
-       return  Tech(red_PSF_with_flush_channels_no_areation);
-    } 
-    elsif(In(mitigation_housing_floor_LU) eq "with_flush_gutters_tubes_no_areation"){
-       return Tech(red_PSF_with_flush_gutters_tubes_no_areation);
-    }  
-    elsif(In(mitigation_housing_floor_LU) eq "with_scraper_metal_slats"){
-       return  Tech(red_PSF_with_scraper_metal_slats);
-    }  
-    elsif(In(mitigation_housing_floor_LU) eq "with_channels_slanted_walls_concrete_slats"){
-       return  Tech(red_PSF_with_channels_slanted_walls_concrete_slats);
-    }  
-    elsif(In(mitigation_housing_floor_LU) eq "with_channel_slanted_walls_metal_slats"){
-       return  Tech(red_PSF_with_channel_slanted_walls_metal_slats);
-    }  
-    elsif(In(mitigation_housing_floor_LU) eq "none"){
-       return 0;
-    };
+    return 0 unless not defined In(mitigation_housing_floor);
+    given ( In(mitigation_housing_floor_LU) ) {
+      when "with_scraper_concrete_slats" {
+        Tech(red_PSF_with_scraper_concrete_slats);
+      }  
+      when "with_flush_channels_no_areation" {
+        Tech(red_PSF_with_flush_channels_no_areation);
+      } 
+      when "with_flush_gutters_tubes_no_areation" {
+        Tech(red_PSF_with_flush_gutters_tubes_no_areation);
+      }  
+      when "with_scraper_metal_slats" {
+        Tech(red_PSF_with_scraper_metal_slats);
+      }  
+      when "with_channels_slanted_walls_concrete_slats" {
+        Tech(red_PSF_with_channels_slanted_walls_concrete_slats);
+      }  
+      when "with_channel_slanted_walls_metal_slats" {
+        Tech(red_PSF_with_channel_slanted_walls_metal_slats);
+      } 
+      when "none" {
+        0;
+      }
+      default {
+        # Warning
+        0;
+      }
+    }
 
++red_housing_floor
+  print = 15
+  ++units 
+    en = -
+  ++description
+    Capture floor mitigation for either model.
+  ++formula
+    Out(red_housing_floor_SHL) + Out(red_housing_floor_LU);
 
-+c_housing_air
++red_housing_air
   print = 15
   ++units 
     en = -
@@ -409,7 +428,7 @@ UNECE 2007. Guidance document on control techniques for preventing and abating e
       else {
           return 0;
       }
-      
+       
        
 
 

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig/Housing/Type.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig/Housing/Type.nhd
@@ -205,7 +205,7 @@ Selects the emission rate and other correciton factors for the specific housing 
         return Val(share_solid,Type::Deep_Litter);
     }
 
-+share_outdoor
++share_indoor
   print=15
   ++units
      en = -


### PR DESCRIPTION
For both model versions 'hr-inclNOxExtended' and 'hr-inclNOxExtendedWithFilters':

- Fix n/tan out housing to include correct air scrubber remains
- Fix wrong aggregated effect of mitigation strategies

and adjust expected values accordingly