### PR TITLE
Dump order

### DIFF
--- a/lib/Agrammon/Documentation.pm6
+++ b/lib/Agrammon/Documentation.pm6
@@ -3,7 +3,7 @@ use Agrammon::Model;
 #| Get model data for LaTeX document generation
 sub get-model-data( Agrammon::Model $model, :%technical! ) {
     my @sections;
-    for $model.evaluation-order.reverse -> $module {
+    for $model.load-order -> $module {
         @sections.push( %(
             :module($module.taxonomy),
             :description($module.description),

--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -145,6 +145,7 @@ class Agrammon::Model {
     has IO::Path $.path;
     has %.preprocessor-options;
     has Agrammon::Model::Module @.evaluation-order;
+    has Agrammon::Model::Module @.load-order;
     has ModuleRunner $!entry-point;
     has %!output-unit-cache;
     has %!output-print-cache;
@@ -203,6 +204,7 @@ class Agrammon::Model {
         given $module.taxonomy -> $tax {
             die "Wrong taxonomy '$tax' in $module-name" unless $tax eq $module-name;
         }
+        @!load-order.push($module);
         my $instance-root = $root;
         $instance-root //= $module.taxonomy if $module.is-multi;
         my $gui-root-module = $root-module;
@@ -305,7 +307,7 @@ class Agrammon::Model {
 
     method dump {
         my Str $output;
-        for @!evaluation-order.reverse {
+        for @!load-order {
             my $level = .taxonomy.comb('::').elems;
             $output  ~= .taxonomy.indent(4 * $level) ~ "\n";
         }

--- a/t/model.t
+++ b/t/model.t
@@ -264,11 +264,11 @@ subtest 'dump()' => {
     my $path = $*PROGRAM.parent.add('test-data/Models/test_simple/');
     my $output-expected = q:to/OUTPUT/;
         Simple
-            Simple::Sub2
-            Simple::Sub2b
-            Simple::Sub2a
             Simple::Sub1
             Simple::Sub1a
+            Simple::Sub2
+            Simple::Sub2a
+            Simple::Sub2b
         OUTPUT
     given 'Simple' -> $module {
         ok my $model = Agrammon::Model.new(:$path);

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Total.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Total.nhd
@@ -23,10 +23,10 @@ taxonomy = Total
 #+DetailsByAnimalCategory
 +PlantProduction
 
-+PlantProduction
-+Application
-+Storage
-+Livestock
+#+PlantProduction
+#+Application
+#+Storage
+#+Livestock
 
 *** output ***
 


### PR DESCRIPTION
- Add @load-order attribute to Model for correctly sorted dump/latex output.
- Revert accidentally checked in external duplication in model.