### PR TITLE
Add --sort for sorting dump/latex output

### DIFF
--- a/lib/Agrammon/Documentation.pm6
+++ b/lib/Agrammon/Documentation.pm6
@@ -3,8 +3,8 @@ use Agrammon::Model;
 #| Get model data for LaTeX document generation
 sub get-model-data( Agrammon::Model $model, $sort, :%technical! ) {
     my @sections;
-    my @order = $sort eq 'calculation' ?? $model.evaluation-order.reverse !! $model.load-order;
-    for @order -> $module {
+    my \order = $sort eq 'calculation' ?? $model.evaluation-order.reverse !! $model.load-order;
+    for order -> $module {
         @sections.push( %(
             :module($module.taxonomy),
             :description($module.description),

--- a/lib/Agrammon/Documentation.pm6
+++ b/lib/Agrammon/Documentation.pm6
@@ -1,9 +1,10 @@
 use Agrammon::Model;
 
 #| Get model data for LaTeX document generation
-sub get-model-data( Agrammon::Model $model, :%technical! ) {
+sub get-model-data( Agrammon::Model $model, $sort, :%technical! ) {
     my @sections;
-    for $model.load-order -> $module {
+    my @order = $sort eq 'calculation' ?? $model.evaluation-order.reverse !! $model.load-order;
+    for @order -> $module {
         @sections.push( %(
             :module($module.taxonomy),
             :description($module.description),
@@ -16,8 +17,8 @@ sub get-model-data( Agrammon::Model $model, :%technical! ) {
 }
 
 #| Create a LaTeX source of the model
-sub create-latex-source( Str $model-name, Agrammon::Model $model, :%technical! ) is export {
-    my @sections = get-model-data( $model, :%technical );
+sub create-latex-source( Str $model-name, Agrammon::Model $model, $sort, :%technical! ) is export {
+    my @sections = get-model-data( $model, $sort, :%technical );
 
     my @latex;
 

--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -307,8 +307,8 @@ class Agrammon::Model {
 
     method dump(Str $sort) {
         my Str $output;
-        my @order = $sort eq 'calculation' ?? @!evaluation-order.reverse !! @!load-order;
-        for @order {
+        my \order = $sort eq 'calculation' ?? @!evaluation-order.reverse !! @!load-order;
+        for order {
             my $level = .taxonomy.comb('::').elems;
             $output  ~= .taxonomy.indent(4 * $level) ~ "\n";
         }

--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -153,7 +153,7 @@ class Agrammon::Model {
     has %!output-labels-cache;
     has %!output-order-cache;
     has $!distribution-map-cache;
-  
+
     method file2module($file) {
         my $module = $file;
         $module ~~ s:g|'/'|::|;
@@ -305,9 +305,10 @@ class Agrammon::Model {
         $!entry-point.run(:$input, :%technical)
     }
 
-    method dump {
+    method dump(Str $sort) {
         my Str $output;
-        for @!load-order {
+        my @order = $sort eq 'calculation' ?? @!evaluation-order.reverse !! @!load-order;
+        for @order {
             my $level = .taxonomy.comb('::').elems;
             $output  ~= .taxonomy.indent(4 * $level) ~ "\n";
         }

--- a/lib/Agrammon/UI/CommandLine.pm6
+++ b/lib/Agrammon/UI/CommandLine.pm6
@@ -57,16 +57,16 @@ multi sub MAIN('run', ExistingFile $filename, ExistingFile $input, Str $tech-fil
 }
 
 #| Dump model
-multi sub MAIN('dump', ExistingFile $filename, Str :$variants = 'SHL') is export {
-    say chomp dump-model $filename.IO, $variants;
+multi sub MAIN('dump', ExistingFile $filename, Str :$variants = 'SHL', Str :$sort = 'model') is export {
+    say chomp dump-model $filename.IO, $variants, $sort;
 }
 
-multi sub MAIN('latex', ExistingFile $filename, Str $tech-file?, Str :$variants = 'SHL') is export {
-    latex $filename.IO, $tech-file, $variants;
+multi sub MAIN('latex', ExistingFile $filename, Str $tech-file?, Str :$variants = 'SHL', Str :$sort = 'model') is export {
+    latex $filename.IO, $tech-file, $variants, $sort;
 }
 
 #| Create LaTeX docu
-sub latex (IO::Path $path, $tech-file, $variants) is export {
+sub latex (IO::Path $path, $tech-file, $variants, $sort) is export {
     die "ERROR: latex expects a .nhd file" unless $path.extension eq 'nhd';
 
     my $module-path = $path.parent;
@@ -84,6 +84,7 @@ sub latex (IO::Path $path, $tech-file, $variants) is export {
     say create-latex-source(
         $model-name,
         $model,
+        $sort,
         technical => %($params.technical.map(-> %module {
             %module.keys[0] => %(%module.values[0].map({ .name => .value }))
         }))
@@ -103,7 +104,7 @@ sub USAGE() is export {
 }
 
 
-sub dump-model (IO::Path $path, $variants) is export {
+sub dump-model (IO::Path $path, $variants, $sort) is export {
     die "ERROR: dump expects a .nhd file" unless $path.extension eq 'nhd';
 
     my $module-path = $path.parent;
@@ -113,7 +114,7 @@ sub dump-model (IO::Path $path, $variants) is export {
     my $model = timed "load $module", {
         load-model-using-cache($*HOME.add('.agrammon'), $module-path, $module, preprocessor-options($variants));
     };
-    return $model.dump;
+    return $model.dump($sort);
 }
 
 sub run (IO::Path $path, IO::Path $input-path, $tech-file, $variants, $language, $prints, Bool $csv, Bool $include-filters,

--- a/lib/Agrammon/UI/CommandLine.pm6
+++ b/lib/Agrammon/UI/CommandLine.pm6
@@ -23,7 +23,8 @@ my %*SUB-MAIN-OPTS =
 ;
 
 subset ExistingFile of Str where { .IO.e or note("No such file $_") && exit 1 }
-subset SupportedLanguage of Str where { $_ ~~ /de|en|fr/ or note("ERROR: --language=[de|en|fr]") && exit 1 };
+subset SupportedLanguage of Str where { $_ ~~ /^ de|en|fr $/ or note("ERROR: --language=[de|en|fr]") && exit 1 };
+subset SortOrder of Str where { $_ ~~ /^ model|calculation $/ or note("ERROR: --sort=[model|calculation]") && exit 1 };
 
 #| Start the web interface
 multi sub MAIN('web', ExistingFile $cfg-filename, ExistingFile $model-filename, Str $tech-file?) is export {
@@ -57,11 +58,11 @@ multi sub MAIN('run', ExistingFile $filename, ExistingFile $input, Str $tech-fil
 }
 
 #| Dump model
-multi sub MAIN('dump', ExistingFile $filename, Str :$variants = 'SHL', Str :$sort = 'model') is export {
+multi sub MAIN('dump', ExistingFile $filename, Str :$variants = 'SHL', SortOrder :$sort = 'model') is export {
     say chomp dump-model $filename.IO, $variants, $sort;
 }
 
-multi sub MAIN('latex', ExistingFile $filename, Str $tech-file?, Str :$variants = 'SHL', Str :$sort = 'model') is export {
+multi sub MAIN('latex', ExistingFile $filename, Str $tech-file?, Str :$variants = 'SHL', SortOrder :$sort = 'model') is export {
     latex $filename.IO, $tech-file, $variants, $sort;
 }
 

--- a/t/documentation.t
+++ b/t/documentation.t
@@ -23,6 +23,7 @@ my $latex;
 lives-ok { $latex = create-latex-source(
         'Model name',
         $model,
+        'model', # sort order
         technical => %($params.technical.map(-> %module {
             %module.keys[0] => %(%module.values[0].map({ .name => .value }))
         }))

--- a/t/model.t
+++ b/t/model.t
@@ -273,7 +273,7 @@ subtest 'dump()' => {
     given 'Simple' -> $module {
         ok my $model = Agrammon::Model.new(:$path);
         $model.load($module);
-        is $model.dump, $output-expected, 'Output as expected';
+        is $model.dump('model'), $output-expected, 'Output as expected';
     }
 }
 


### PR DESCRIPTION
I wonder if it should be `@order := ...`, but then the doing the `.reverse` inside the ternary wouldn't work I suppose.