### PR TITLE
Add filter groups with no inputs to output

### DIFF
--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -147,6 +147,8 @@ class Agrammon::Model {
     has Agrammon::Model::Module @.evaluation-order;
     has Agrammon::Model::Module @.load-order;
     has ModuleRunner $!entry-point;
+    has %.filter-groups;
+    has %.module-hash;
     has %!output-unit-cache;
     has %!output-print-cache;
     has %!output-format-cache;
@@ -228,6 +230,14 @@ class Agrammon::Model {
 
         my $evaluator = ModuleRunner.new(:$module, :@dependencies);
         %loaded{$module-name} = $evaluator;
+        %!module-hash{$module-name} = $module;
+        for $module.input -> $input {
+            my @keys;
+            next unless $input.is-filter;
+            for $input.as-hash<enum>.keys -> $key {
+                %!filter-groups{ $module-name ~ '::' ~ $input.name  }{$key} = True;
+            }
+        }
         return $evaluator;
     }
 

--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -148,7 +148,6 @@ class Agrammon::Model {
     has Agrammon::Model::Module @.load-order;
     has ModuleRunner $!entry-point;
     has %.filter-groups;
-    has %.module-hash;
     has %!output-unit-cache;
     has %!output-print-cache;
     has %!output-format-cache;
@@ -230,7 +229,6 @@ class Agrammon::Model {
 
         my $evaluator = ModuleRunner.new(:$module, :@dependencies);
         %loaded{$module-name} = $evaluator;
-        %!module-hash{$module-name} = $module;
         for $module.input -> $input {
             my @keys;
             next unless $input.is-filter;

--- a/lib/Agrammon/OutputFormatter/JSON.pm6
+++ b/lib/Agrammon/OutputFormatter/JSON.pm6
@@ -93,10 +93,25 @@ sub make-record($fq-name, $output, $model, $raw-value, $var, :$language, :$print
 sub push-filters(@records, $fq-name, $output, $model,
                  Agrammon::Outputs::FilterGroupCollection $collection,
                  $var) {
+    # model filter groups
+    my %fgs = $model.filter-groups;
+
+    # add existing filter groups
     for $collection.results-by-filter-group {
         my %filters := .key;
         my $value   := .value;
         push @records, make-record($fq-name, $output, $model, $value, $var, :%filters);
+        for %filters.kv -> $key, $value {
+            # remove from model filter group
+            %fgs{$key}{$value}:delete;
+        }
+    }
+
+    # add remaining model filter groups
+    for %fgs.kv -> $fg, %values {
+        for %values.kv -> $key, $value {
+            push @records, make-record($fq-name, $output, $model, Nil, $var, :filters( %( $fg => $key) ) );
+        }
     }
 }
 


### PR DESCRIPTION
- At least some of the reports must show all filter groups (all animal categories), even those that have no inputs.
- Will add a switch for turning this on/off and handling in the frontend in a later PR
Not sure this is the most efficient way to do this.