### PR TITLE
Retain order of enums when producing options

### DIFF
--- a/lib/Agrammon/CommonParser.pm6
+++ b/lib/Agrammon/CommonParser.pm6
@@ -5,6 +5,7 @@ role Agrammon::CommonParser {
 
     token section-heading($title) {
         \h* '***' \h* $title \h* '***' \h* \n
+        { $*CUR-SECTION = $title }
     }
 
     token option-section {

--- a/lib/Agrammon/Model/Input.pm6
+++ b/lib/Agrammon/Model/Input.pm6
@@ -19,12 +19,13 @@ class Agrammon::Model::Input {
     #    has Str @.optionsLang; # XXX set correct type: array of hashes
     has @.options;     # XXX set correct type: array of arrays
     has @.options-lang; # XXX set correct type: array of hashes
-    has  %.enum;
+    has @!enum-order;
+    has %!enum-lookup;
     has Int $.order;
     has Bool $!branch = False;
     has Bool $!filter = False;
 
-    submethod TWEAK(:$default_calc, :$default_gui, :$branch, :$filter) {
+    submethod TWEAK(:$default_calc, :$default_gui, :$branch, :$filter, :@enum --> Nil) {
         with $default_calc {
             $!default-calc = val($_);
         }
@@ -36,12 +37,18 @@ class Agrammon::Model::Input {
                 $!branch = True;
             }
         }
+        if @enum {
+            @!enum-order = @enum;
+            %!enum-lookup = @enum;
+        }
         with $filter {
             if .lc eq 'true' {
                 $!filter = True;
             }
         }
     }
+
+    method enum(--> Hash) { %!enum-lookup }
 
     method is-branch(--> Bool) { $!branch }
 
@@ -63,9 +70,10 @@ class Agrammon::Model::Input {
 
         my @options;
         my @options-lang;
-        my %enums = %!enum;
 
-        for %enums.kv -> $name, $optLang {
+        for @!enum-order {
+            my $name = .key;
+            my $optLang = .value;
             my $label   = $name;
             $label      ~~ s:g/_/ /;
             my @opt     = [ $label, '', $name];
@@ -85,7 +93,7 @@ class Agrammon::Model::Input {
                 calc => $.default-calc,
                 gui  => $.default-gui,
             ),
-            enum        => %!enum,
+            enum        => %!enum-lookup,
             help        => %!help,
             labels      => %!labels,
             models      => @!models || @("all"),

--- a/lib/Agrammon/ModuleBuilder.pm6
+++ b/lib/Agrammon/ModuleBuilder.pm6
@@ -8,6 +8,10 @@ use Agrammon::Model::Test;
 use Agrammon::Model::Technical;
 
 class Agrammon::ModuleBuilder {
+    my constant ORDERED = {
+        input => { :enum }
+    }
+
     method TOP($/) {
         make Agrammon::Model::Module.new(|flat($<section>.map(*.ast)).Map);
     }
@@ -80,7 +84,10 @@ class Agrammon::ModuleBuilder {
     }
 
     method subsection-map($/) {
-        make ~$<key> => %( $<value>.map(*.ast) );
+        my $key = ~$<key>;
+        make $key => ORDERED{$*CUR-SECTION}{$key}
+                ?? @( $<value>.map(*.ast) )
+                !! %( $<value>.map(*.ast) );
     }
 
     method single-line-option($/) {

--- a/lib/Agrammon/ModuleParser.pm6
+++ b/lib/Agrammon/ModuleParser.pm6
@@ -4,6 +4,7 @@ use Agrammon::CommonParser;
 grammar Agrammon::ModuleParser does Agrammon::CommonParser {
     token TOP {
         :my $*TAXONOMY = '';
+        :my $*CUR-SECTION = '';
         <.blank-line>*
         <section>+
         [

--- a/lib/Agrammon/TechnicalParser.pm6
+++ b/lib/Agrammon/TechnicalParser.pm6
@@ -4,6 +4,7 @@ use Agrammon::TechnicalBuilder;
 
 grammar Agrammon::TechnicalParser does Agrammon::CommonParser {
     token TOP {
+        :my $*CUR-SECTION = '';
         <.blank-line>*
         <.section-heading('technical_parameters')>
         [


### PR DESCRIPTION
So that the UI can access them in the order that they were originally
provided in the .nhd file. Should resolve #297.