### PR TITLE
Allow null values for inputs

### DIFF
--- a/share/agrammon.openapi
+++ b/share/agrammon.openapi
@@ -673,6 +673,7 @@ components:
                     oneOf:
                         - type: integer
                         - type: string
+                    nullable: true
                 row:
                     description: Row
                     type: integer


### PR DESCRIPTION
... to avoid 409 errors when creating a new dataset or when clearing an input in the GUI.