### PR TITLE
All groups for output

### DIFF
--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -95,7 +95,7 @@ class Agrammon::Model {
                 $outputs.declare-multi-instance($tax);
                 for $input.inputs-list-for($tax) -> $multi-input {
                     my %filters := $!filter-set.filters-for($multi-input);
-                    my $multi-output = $outputs.new-instance($tax, $multi-input.instance-id, :%filters);
+                    my $multi-output = $outputs.new-instance($tax, $multi-input.instance-id, :%filters, :$!filter-set);
                     self!run-as-single($multi-input, %technical, $multi-output, %run-already.clone);
                 }
                 self!mark-multi-run(%run-already);

--- a/lib/Agrammon/Model/FilterSet.pm6
+++ b/lib/Agrammon/Model/FilterSet.pm6
@@ -13,9 +13,10 @@ class Agrammon::Model::FilterSet {
     }
 
     has Filter @!filters;
+    has Agrammon::Model::Module $.module;
 
-    submethod BUILD(Agrammon::Model::Module :$module!, :@dependencies! --> Nil) {
-        self!add-from-module($module);
+    submethod BUILD(Agrammon::Model::Module :$!module!, :@dependencies! --> Nil) {
+        self!add-from-module($!module);
         self!add-from-module($_) for @dependencies;
     }
 

--- a/lib/Agrammon/Model/Input.pm6
+++ b/lib/Agrammon/Model/Input.pm6
@@ -46,6 +46,8 @@ class Agrammon::Model::Input {
 
     method enum(--> Hash) { %!enum-lookup }
 
+    method enum-ordered(--> Array) { @!enum-order }
+
     method is-branch(--> Bool) { $!branch }
 
     method is-filter(--> Bool) { $!filter }

--- a/lib/Agrammon/Outputs/FilterGroupCollection.pm6
+++ b/lib/Agrammon/Outputs/FilterGroupCollection.pm6
@@ -67,7 +67,7 @@ class Agrammon::Outputs::FilterGroupCollection {
                 die "Can only get all values when provenance of the filter group was provided";
             }
             my @results;
-            for $!provenance.keys.sort.reverse -> $filter-set {
+            for $!provenance.keys.sort(*.module.taxonomy).reverse -> $filter-set {
                 for $filter-set.all-possible-filter-keys -> %filters {
                     my $key = FilterKey.new(:%filters);
                     @results.push(%filters => %!values-by-filter{$key} // 0);

--- a/lib/Agrammon/Outputs/FilterGroupCollection.pm6
+++ b/lib/Agrammon/Outputs/FilterGroupCollection.pm6
@@ -64,10 +64,10 @@ class Agrammon::Outputs::FilterGroupCollection {
     method results-by-filter-group(Bool :$all = False) {
         if $all {
             if %!values-by-filter && !$!provenance {
-                die "Can only got all values when provenance of the filter group was provided";
+                die "Can only get all values when provenance of the filter group was provided";
             }
             my @results;
-            for $!provenance.keys -> $filter-set {
+            for $!provenance.keys.sort.reverse -> $filter-set {
                 for $filter-set.all-possible-filter-keys -> %filters {
                     my $key = FilterKey.new(:%filters);
                     @results.push(%filters => %!values-by-filter{$key} // 0);
@@ -162,13 +162,13 @@ class Agrammon::Outputs::FilterGroupCollection {
                 else {
                     # Push 0 if their value > threshold, but key is not existing
                     # 0 because of missing flow (zero flow)
-                    @result-instances.push: $their-key => 0;                    
-                } 
-            } 
+                    @result-instances.push: $their-key => 0;
+                }
+            }
             elsif $push-all {
                 # Push threshold if their value <= threshold. Could also be 0,
                 # but it might become handy for limiting ratio to 1, i.e. threshold = 1?
-                @result-instances.push: $their-key => $thresh;                
+                @result-instances.push: $their-key => $thresh;
             }
         }
 

--- a/t/model-with-filters.t
+++ b/t/model-with-filters.t
@@ -90,6 +90,17 @@ subtest 'Running the model produces output instances with filters' => {
             is .elems, 1, 'Found filter group value for boars';
             is .[0].value, <238158/10625>, 'Correct value calculated for boars';
         }
+        my @all-results-by-group = $livestock-tan.results-by-filter-group(:all);
+        given @all-results-by-group[0] {
+            ok .key eqv {"Livestock::Pig::Excretion::animalcategory" => 'nursing_sows'},
+                    'First key is first enum element';
+            is-deeply .value, <347116/5625>, 'Correct value';
+        }
+        given @all-results-by-group[2] {
+            ok .key eqv {"Livestock::Pig::Excretion::animalcategory" => 'gilts'},
+                'Have a key included without a value';
+            is-deeply .value, 0, 'Zero value';
+        }
     }
 
     subtest 'filterGroup builtin' => {
@@ -97,7 +108,6 @@ subtest 'Running the model produces output instances with filters' => {
             isa-ok $factor, Agrammon::Outputs::FilterGroupCollection,
                     'filterGroup builtin will produce a filter group collection';
             my @results-by-group = $factor.results-by-filter-group;
-            dd @results-by-group;
             given @results-by-group.grep(*.key eqv { "Livestock::Pig::Excretion::animalcategory" => "boars" }) {
                 is .elems, 1, 'Found filter group value for boars';
                 is .[0].value, 0.75, 'Correct value for boars';

--- a/t/test-data/agrammon.cfg.yaml
+++ b/t/test-data/agrammon.cfg.yaml
@@ -7,6 +7,8 @@ General:
 Database:
     name:     agrammon_test
     host:     localhost
+#    host:     192.168.0.143
+#    host:     10.46.102.25
     user:     agrammon
     password: agrammonATwork
 


### PR DESCRIPTION
This hopefully provides a solution to #299. If you call `.results-by-filter-group(:all)` (note the new ':all` named argument), then it will include all possible filter keys that could exist (based on the `enum`s in the definitions) rather than just those that have been used in an instance. A `0` value is given to those that have no instances.

This is achieved by dynamic means: filter group collections are constructed with the filter set(s) from the model of all modules that contribute values to the group. This is mostly a case of passing it along, with the exception of pairwise operations which need to perform a union of the module filter sets (thus how a `P+` involving two different modules will end up with the filter sets of both being accounted for).

Hopefully this provides the desired semantics, and also will make it an easy change in the output productions too (I did not update those; @zaucker it's probably best to check out this branch and have a go at updating the output logic and seeing if it does the right thing).