### PR TITLE
Sort filter groups by load order

### DIFF
--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -72,7 +72,6 @@ class Agrammon::Model {
         has Agrammon::Model::Module $.module;
         has ModuleRunner @.dependencies;
         has Agrammon::Model::FilterSet $!filter-set;
-        has Agrammon::ModuleBuilder $!module-builder = Agrammon::ModuleBuilder.new;
         
         submethod TWEAK(--> Nil) {
             if $!module.is-multi {
@@ -147,6 +146,7 @@ class Agrammon::Model {
     has %.preprocessor-options;
     has Agrammon::Model::Module @.evaluation-order;
     has Agrammon::Model::Module @.load-order;
+    has Agrammon::ModuleBuilder $!module-builder = Agrammon::ModuleBuilder.new;
     has ModuleRunner $!entry-point;
     has %!output-unit-cache;
     has %!output-print-cache;

--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -72,7 +72,8 @@ class Agrammon::Model {
         has Agrammon::Model::Module $.module;
         has ModuleRunner @.dependencies;
         has Agrammon::Model::FilterSet $!filter-set;
-
+        has Agrammon::ModuleBuilder $!module-builder = Agrammon::ModuleBuilder.new;
+        
         submethod TWEAK(--> Nil) {
             if $!module.is-multi {
                 $!filter-set .= new(:$!module, :dependencies(@!dependencies.map(*.module)));
@@ -176,7 +177,7 @@ class Agrammon::Model {
         {
             return Agrammon::ModuleParser.parse(
                 preprocess($file.slurp, %!preprocessor-options),
-                actions => Agrammon::ModuleBuilder
+                actions => $!module-builder
             ).ast;
             CATCH {
                 die "Failed to parse module $file:\n$_";

--- a/lib/Agrammon/Model/Module.pm6
+++ b/lib/Agrammon/Model/Module.pm6
@@ -27,6 +27,7 @@ class Agrammon::Model::Module {
     has %.technical-hash;
     has $.instance-root;
     has Agrammon::Model::Module $.gui-root-module;
+    has Int $.load-order;
 
     submethod TWEAK {
         my $tax = $!taxonomy;

--- a/lib/Agrammon/ModuleBuilder.pm6
+++ b/lib/Agrammon/ModuleBuilder.pm6
@@ -8,14 +8,14 @@ use Agrammon::Model::Test;
 use Agrammon::Model::Technical;
 
 class Agrammon::ModuleBuilder {
+    has $!module-load-order = 0;
+    
     my constant ORDERED = {
         input => { :enum }
     }
 
-    my Int $module-load-order = 0;
-
     method TOP($/) {
-        make Agrammon::Model::Module.new(|flat($<section>.map(*.ast)).Map, :load-order($module-load-order++));
+        make Agrammon::Model::Module.new(|flat($<section>.map(*.ast)).Map, :load-order($!module-load-order++));
     }
 
     method section:sym<general>($/) {

--- a/lib/Agrammon/ModuleBuilder.pm6
+++ b/lib/Agrammon/ModuleBuilder.pm6
@@ -12,8 +12,10 @@ class Agrammon::ModuleBuilder {
         input => { :enum }
     }
 
+    my Int $module-load-order = 0;
+
     method TOP($/) {
-        make Agrammon::Model::Module.new(|flat($<section>.map(*.ast)).Map);
+        make Agrammon::Model::Module.new(|flat($<section>.map(*.ast)).Map, :load-order($module-load-order++));
     }
 
     method section:sym<general>($/) {

--- a/lib/Agrammon/Outputs/FilterGroupCollection.pm6
+++ b/lib/Agrammon/Outputs/FilterGroupCollection.pm6
@@ -67,7 +67,7 @@ class Agrammon::Outputs::FilterGroupCollection {
                 die "Can only get all values when provenance of the filter group was provided";
             }
             my @results;
-            for $!provenance.keys.sort(*.module.taxonomy).reverse -> $filter-set {
+            for $!provenance.keys.sort(*.module.load-order) -> $filter-set {
                 for $filter-set.all-possible-filter-keys -> %filters {
                     my $key = FilterKey.new(:%filters);
                     @results.push(%filters => %!values-by-filter{$key} // 0);

--- a/lib/Agrammon/Outputs/FilterGroupCollection.pm6
+++ b/lib/Agrammon/Outputs/FilterGroupCollection.pm6
@@ -62,15 +62,13 @@ class Agrammon::Outputs::FilterGroupCollection {
     #| selected will be included, even if no instance used them, and they will
     #| have a zero value.
     method results-by-filter-group(Bool :$all = False) {
-        if $all {
-            if %!values-by-filter && !$!provenance {
-                die "Can only get all values when provenance of the filter group was provided";
-            }
+        if $!provenance {
             my @results;
             for $!provenance.keys.sort(*.module.load-order) -> $filter-set {
                 for $filter-set.all-possible-filter-keys -> %filters {
                     my $key = FilterKey.new(:%filters);
-                    @results.push(%filters => %!values-by-filter{$key} // 0);
+                    $all ?? @results.push(%filters => %!values-by-filter{$key} // 0)
+                         !! @results.push(%filters => $_) with %!values-by-filter{$key};
                 }
             }
             with %!values-by-filter{FilterKey.empty} {
@@ -79,18 +77,7 @@ class Agrammon::Outputs::FilterGroupCollection {
             @results
         }
         else {
-#            @results = [%!values-by-filter.map({ .key.filters => .value })]
-            my @results;
-            for $!provenance.keys.sort(*.module.load-order) -> $filter-set {
-                for $filter-set.all-possible-filter-keys -> %filters {
-                    my $key = FilterKey.new(:%filters);
-                    @results.push(%filters => %!values-by-filter{$key} // 0) if %!values-by-filter{$key}:exists;
-                }
-            }
-            with %!values-by-filter{FilterKey.empty} {
-                @results.push({} => $_);
-            }
-            @results
+            [%!values-by-filter.map({ .key.filters => .value })]
         }
     }
 

--- a/lib/Agrammon/Outputs/FilterGroupCollection.pm6
+++ b/lib/Agrammon/Outputs/FilterGroupCollection.pm6
@@ -67,8 +67,12 @@ class Agrammon::Outputs::FilterGroupCollection {
             for $!provenance.keys.sort(*.module.load-order) -> $filter-set {
                 for $filter-set.all-possible-filter-keys -> %filters {
                     my $key = FilterKey.new(:%filters);
-                    $all ?? @results.push(%filters => %!values-by-filter{$key} // 0)
-                         !! @results.push(%filters => $_) with %!values-by-filter{$key};
+                    if $all {
+                        @results.push(%filters => %!values-by-filter{$key} // 0);
+                    }
+                    else {
+                        @results.push(%filters => $_) with %!values-by-filter{$key};
+                    }
                 }
             }
             with %!values-by-filter{FilterKey.empty} {

--- a/lib/Agrammon/Outputs/FilterGroupCollection.pm6
+++ b/lib/Agrammon/Outputs/FilterGroupCollection.pm6
@@ -79,7 +79,18 @@ class Agrammon::Outputs::FilterGroupCollection {
             @results
         }
         else {
-            [%!values-by-filter.map({ .key.filters => .value })]
+#            @results = [%!values-by-filter.map({ .key.filters => .value })]
+            my @results;
+            for $!provenance.keys.sort(*.module.load-order) -> $filter-set {
+                for $filter-set.all-possible-filter-keys -> %filters {
+                    my $key = FilterKey.new(:%filters);
+                    @results.push(%filters => %!values-by-filter{$key} // 0) if %!values-by-filter{$key}:exists;
+                }
+            }
+            with %!values-by-filter{FilterKey.empty} {
+                @results.push({} => $_);
+            }
+            @results
         }
     }
 

--- a/t/module-parser.t
+++ b/t/module-parser.t
@@ -9,7 +9,7 @@ for "$test-root/CMilk.nhd", "$test-root/CMilk-crazy-ws.nhd" -> $module-file {
     subtest "Loading $module-file" => {
         my $parsed = Agrammon::ModuleParser.parsefile(
             $module-file,
-            actions => Agrammon::ModuleBuilder
+            actions => Agrammon::ModuleBuilder.new
         );
         ok $parsed, "Successfully parsed $module-file";
 
@@ -99,7 +99,7 @@ my $module-file = "$test-root/CMilkWithTests.nhd";
 subtest "Loading $module-file" => {
     my $parsed = Agrammon::ModuleParser.parsefile(
         $module-file,
-        actions => Agrammon::ModuleBuilder
+        actions => Agrammon::ModuleBuilder.new
     );
     ok $parsed, "Successfully parsed $module-file";
 
@@ -122,7 +122,7 @@ $module-file = "$test-root/PlantProduction.nhd";
 subtest "Loading $module-file" => {
     my $parsed = Agrammon::ModuleParser.parsefile(
         $module-file,
-        actions => Agrammon::ModuleBuilder
+        actions => Agrammon::ModuleBuilder.new
     );
     ok $parsed, "Successfully parsed $module-file";
 
@@ -147,7 +147,7 @@ $module-file = "$test-root/DairyCow.nhd";
 subtest "Loading $module-file" => {
     my $parsed = Agrammon::ModuleParser.parsefile(
         $module-file,
-        actions => Agrammon::ModuleBuilder
+        actions => Agrammon::ModuleBuilder.new
     );
     ok $parsed, "Successfully parsed $module-file";
 
@@ -161,7 +161,7 @@ $module-file = "$test-root/Models/hr-limit-2010/Livestock/Poultry/Excretion.nhd"
 subtest "Loading $module-file" => {
     my $parsed = Agrammon::ModuleParser.parsefile(
         $module-file,
-        actions => Agrammon::ModuleBuilder
+        actions => Agrammon::ModuleBuilder.new
     );
     ok $parsed, "Successfully parsed $module-file";
     my $model = $parsed.ast;


### PR DESCRIPTION
While sorting by taxonomy alphabetically gives a reproducable sorting, for the users it will be more logical to have the filter groups sorted by module load order, because this order is also reflected in the GUI.