### PR TITLE
Issue with variant

### DIFF
--- a/t/run-complex-model-with-variants.t
+++ b/t/run-complex-model-with-variants.t
@@ -16,8 +16,8 @@ my $model-version = 'hr-inclNOxExtendedWithFilters';
 my $model-variants = (
     # # model version for web (Baugesuch Kanton Luzern)
     # 'Kantonal_LU',
-    # # model version for command line (no reports, extended variable output)
-    # 'Single_extendedOutput',
+    # model version for command line (no reports, extended variable output)
+    'Single_extendedOutput',
     # # model version for command line (checking N/TAN flows)
     # 'Single_checkBalance',
     # # default model version for web (detailed reports, reduced variable output)

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/DairyCow.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/DairyCow.nhd
@@ -47,7 +47,7 @@ gui = Livestock::DairyCow,Tierhaltung::Milchkühe,Production animale::Vâches la
     }
 
 
-?if Single_extendedOutput
+#?if Single_extendedOutput
 
 +animals
   print = DairyCow
@@ -321,4 +321,4 @@ gui = Livestock::DairyCow,Tierhaltung::Milchkühe,Production animale::Vâches la
 
 ########################
 
-?endif
+#?endif

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Equides.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Equides.nhd
@@ -28,7 +28,7 @@ and grazing. Further it summarizes the annual N flux from the housing to the sto
 
 *** output ***
 
-?if Single_extendedOutput
+#?if Single_extendedOutput
 
 +animals
   print = Equides
@@ -303,4 +303,4 @@ and grazing. Further it summarizes the annual N flux from the housing to the sto
 
 ########################
 
-?endif
+ #?endif

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Equides.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Equides.nhd
@@ -28,7 +28,7 @@ and grazing. Further it summarizes the annual N flux from the housing to the sto
 
 *** output ***
 
-#?if Single_extendedOutput
+?if Single_extendedOutput
 
 +animals
   print = Equides
@@ -38,6 +38,8 @@ and grazing. Further it summarizes the annual N flux from the housing to the sto
     Number of dairy cows in barn.
   ++formula
     Val(animals, Equides::Excretion);
+
+?endif
 
 +animalcategory
   print = Equides
@@ -303,4 +305,4 @@ and grazing. Further it summarizes the annual N flux from the housing to the sto
 
 ########################
 
- #?endif
+#?endif

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/FatteningPigs.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/FatteningPigs.nhd
@@ -47,7 +47,7 @@ gui       = Livestock::FatteningPigs,Tierhaltung::Mastschweine,Production animal
       return "barn dimensioning ok";
     }
 
-?if Single_extendedOutput
+#?if Single_extendedOutput
 
 +animals
   print = FatteningPigs
@@ -240,4 +240,4 @@ gui       = Livestock::FatteningPigs,Tierhaltung::Mastschweine,Production animal
 
 ########################
 
-?endif
+#?endif

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/OtherCattle.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/OtherCattle.nhd
@@ -49,7 +49,7 @@ gui       = Livestock::OtherCattle,Tierhaltung::Übriges Rindvieh,Production ani
       return "barn dimensioning ok";
     }
 
-?if Single_extendedOutput
+#?if Single_extendedOutput
 
 +animals
   print = OtherCattle
@@ -324,4 +324,4 @@ gui       = Livestock::OtherCattle,Tierhaltung::Übriges Rindvieh,Production ani
 
 ########################
 
-?endif
+#?endif

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Pig.nhd
@@ -48,7 +48,7 @@ gui       = Livestock::Pig,Tierhaltung::Zuchtschweine,Production animale::Porcs,
     }
 
 
-?if Single_extendedOutput
+#?if Single_extendedOutput
 
 +animals
   print = Pig
@@ -240,4 +240,4 @@ gui       = Livestock::Pig,Tierhaltung::Zuchtschweine,Production animale::Porcs,
 
 ########################
 
-?endif
+#?endif

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Poultry.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/Poultry.nhd
@@ -48,7 +48,7 @@ gui       = Livestock::Poultry,Tierhaltung::Geflügel,Production animale::Volail
     }
 
 
-?if Single_extendedOutput
+#?if Single_extendedOutput
 
 +animals
   print = Poultry
@@ -240,4 +240,4 @@ gui       = Livestock::Poultry,Tierhaltung::Geflügel,Production animale::Volail
 
 ########################
 
-?endif
+#?endif

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/RoughageConsuming.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/RoughageConsuming.nhd
@@ -28,7 +28,7 @@ gui       = Livestock::RoughageConsuming,Tierhaltung::Andere Raufutterverzehrer,
 
 *** output ***
 
-?if Single_extendedOutput
+#?if Single_extendedOutput
 
 +animals
   print = RoughageConsuming
@@ -221,4 +221,4 @@ gui       = Livestock::RoughageConsuming,Tierhaltung::Andere Raufutterverzehrer,
 
 ########################
 
-?endif
+#?endif

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/SmallRuminants.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock/SmallRuminants.nhd
@@ -31,7 +31,7 @@ Summarizes the annual N flux from housing to the storage for goats, fattening sh
 
 *** output ***
 
-?if Single_extendedOutput
+#?if Single_extendedOutput
 
 +animals
   print = SmallRuminants
@@ -225,4 +225,4 @@ Summarizes the annual N flux from housing to the storage for goats, fattening sh
 ########################
 
 
-?endif
+#?endif


### PR DESCRIPTION
@jnthn this code fails for model variant `Single_extendedOutput`. It runs through if either variant is other than `Single_extendedOutput` or if the `?if` statement is removed/commented. The following error occurs if variant `Single_extendedOutput` is run:
```
# Failed test 'Load module End.nhd with variant Single_extendedOutput from /home/christoph/repos/5_GitHub/agrammon-workbench/agrammon/t/test-data/Models/hr-inclNOxExtendedWithFilters/'                                
# at /home/christoph/repos/5_GitHub/agrammon-workbench/agrammon/t/run-complex-model-with-variants.t line 46
# Cannot look up attributes in a Agrammon::Model::Output type object
```