### PR TITLE
Fix a formula compilation bug with preproc use

### DIFF
--- a/lib/Agrammon/ModelCache.pm6
+++ b/lib/Agrammon/ModelCache.pm6
@@ -13,7 +13,7 @@ sub load-model-using-cache(IO() $cache-dir, IO() $path, $module, %preprocessor-o
             unit module {$hash};
             use Agrammon::Model;
             our $model = BEGIN Agrammon::Model
-                    .new(path => {$path.absolute.perl}.IO)
+                    .new(path => {$path.absolute.perl}.IO, preprocessor-options => {%preprocessor-options.raku})
                     .load({$module.perl}, :!compile-formulas);
             my @modules := $model.evaluation-order;
             {set-formulas-code($m)}


### PR DESCRIPTION
The code to precompile formulas failed to pass along the preprocessor
options in the model setup code, resulting in an inconsistency that
could in turn lead to it trying to set up formulas on outputs that were
disabled thanks to the preprocessor. Fixes the issue reported in #316.