### PR TITLE
Add expected results for model variants

### DIFF
--- a/t/run-complex-model-with-variants.t
+++ b/t/run-complex-model-with-variants.t
@@ -27,11 +27,21 @@ my $model-variants = (
     );
 
 #| Expected results
-my $nh3-ntotal = 3157.775;
-my $nh3-nanimalproduction = 3135.575;
-my $nh3-napplication = 1351.033;
-my $n-into-application = 7480.652;
-my $tan-into-application = 3202.854;
+my %expected-results =
+    'Kantonal_LU' => {
+        'nh3_ntotal' => 3299.47,    
+        'nh3_nanimalproduction' => 3277.27,    
+        'nh3_napplication' => 1491.068,    
+        'n_into_application' => 7692.974,    
+        'tan_into_application' => 3336.359    
+    },
+    'Single_default' => {
+        'nh3_ntotal' => 3157.775,    
+        'nh3_nanimalproduction' => 3135.575,    
+        'nh3_napplication' => 1351.033,    
+        'n_into_application' => 7480.652,    
+        'tan_into_application' => 3202.854    
+    };
 
 my $filename = 'hr-inclNOxExtendedWithFilters-model-input.csv';
 my $fh = open $*PROGRAM.parent.add("test-data/$filename");
@@ -68,17 +78,16 @@ for $model-variants.values -> $variant {
                 'Successfully executed model';
         my %output-hash = $output.get-outputs-hash;
 
-        is (+%output-hash<Total><nh3_ntotal>).round(.001), $nh3-ntotal.round(.001),
+        is (+%output-hash<Total><nh3_ntotal>).round(.001), %expected-results{$variant}{'nh3_ntotal'}:v.round(.001),
                 "Correct nh3_ntotal result: { (+%output-hash<Total><nh3_ntotal>).round(.001) }";
-        is (+%output-hash<Total><nh3_nanimalproduction>).round(.001), $nh3-nanimalproduction.round(.001),
+        is (+%output-hash<Total><nh3_nanimalproduction>).round(.001), %expected-results{$variant}{'nh3_nanimalproduction'}:v.round(.001),
                 "Correct nh3_nanimalproduction result: { (+%output-hash<Total><nh3_nanimalproduction>).round(.001) }";
-        is (+%output-hash<Application><nh3_napplication>).round(.001), $nh3-napplication.round(.001),
+        is (+%output-hash<Application><nh3_napplication>).round(.001), %expected-results{$variant}{'nh3_napplication'}:v.round(.001),
                 "Correct nh3_napplication result: { (+%output-hash<Application><nh3_napplication>).round(.001) }";
-        is (+%output-hash<Storage><n_into_application>).round(.001), $n-into-application.round(.001),
+        is (+%output-hash<Storage><n_into_application>).round(.001), %expected-results{$variant}{'n_into_application'}:v.round(.001),
                 "Correct n_into_application result: { (+%output-hash<Storage><n_into_application>).round(.001) }";
-        is (+%output-hash<Storage><tan_into_application>).round(.001), $tan-into-application.round(.001),
+        is (+%output-hash<Storage><tan_into_application>).round(.001), %expected-results{$variant}{'tan_into_application'}:v.round(.001),
                 "Correct tan_into_application result: { (+%output-hash<Storage><tan_into_application>).round(.001) }";
-
 
        # say "\nFluxSummaryLivestock=\n", output-as-text($model, $output, 'de', 'FluxSummaryLivestock,TANFlux', False);
        # say "\nFluxSummaryLivestock (Details)=\n", output-as-text($model, $output, 'de', 'FluxSummaryLivestock,TANFlux', True);

--- a/t/run-complex-model-with-variants.t
+++ b/t/run-complex-model-with-variants.t
@@ -29,11 +29,25 @@ my $model-variants = (
 #| Expected results
 my %expected-results =
     'Kantonal_LU' => {
-        'nh3_ntotal' => 3299.47,    
-        'nh3_nanimalproduction' => 3277.27,    
-        'nh3_napplication' => 1491.068,    
+        'nh3_ntotal' => 3358.751,    
+        'nh3_nanimalproduction' => 3336.551,    
+        'nh3_napplication' => 1550.348,    
         'n_into_application' => 7692.974,    
         'tan_into_application' => 3336.359    
+    },
+    'Single_correct' => {
+        'nh3_ntotal' => 3153.837,    
+        'nh3_nanimalproduction' => 3131.637,    
+        'nh3_napplication' => 1347.095,    
+        'n_into_application' => 7480.652,    
+        'tan_into_application' => 3202.854   
+    },
+    'Single_extendedOutput' => {
+        'nh3_ntotal' => 3157.775,    
+        'nh3_nanimalproduction' => 3135.575,    
+        'nh3_napplication' => 1351.033,    
+        'n_into_application' => 7480.652,    
+        'tan_into_application' => 3202.854  
     },
     'Single_default' => {
         'nh3_ntotal' => 3157.775,    


### PR DESCRIPTION
- no variant is tested yet to "safe time" when opening new PRs