### PR TITLE
Filter key translation

### DIFF
--- a/lib/Agrammon/OutputFormatter/JSON.pm6
+++ b/lib/Agrammon/OutputFormatter/JSON.pm6
@@ -29,7 +29,6 @@ sub get-data($model, $outputs, $include-filters, $language?, $prints?) {
                 my $var = $module ~ '::' ~ $output;
                 push @records, make-record($module, $output, $model, $raw-value, $var, :$language, :$prints);
                 if $include-filters {
-                    my $value = flat-value($raw-value);
                     if $raw-value ~~ Agrammon::Outputs::FilterGroupCollection && $raw-value.has-filters {
                         push-filters(@records, $module, $output, $model, $raw-value, $var);
                     }
@@ -44,7 +43,6 @@ sub get-data($model, $outputs, $include-filters, $language?, $prints?) {
                         my $var = $q-name ~ '::' ~ $output;
                         push @records, make-record($fq-name, $output, $model, $raw-value, $var, $instance-id, :$language, :$prints);
                         if $include-filters {
-                            my $value = flat-value($raw-value);
                             if $raw-value ~~ Agrammon::Outputs::FilterGroupCollection && $raw-value.has-filters {
                                 push-filters(@records, $fq-name, $output, $model, $raw-value, $var);
                             }

--- a/lib/Agrammon/Outputs/FilterGroupCollection.pm6
+++ b/lib/Agrammon/Outputs/FilterGroupCollection.pm6
@@ -183,3 +183,17 @@ class Agrammon::Outputs::FilterGroupCollection {
         %!values-by-filter
     }
 }
+
+sub translate-filter-keys($model, %filter) is export {
+    Hash[Hash, Hash].new: %filter.kv.map: -> $key, $value {
+        my @parts = $key.split('::');
+        my $input-name = @parts.pop;
+        my $taxonomy = @parts.join('::');
+        with $model.get-input($taxonomy, $input-name) -> $input {
+            $input.labels => $input.enum{$value}
+        }
+        else {
+            $key => $value
+        }
+    }
+}

--- a/t/model-with-filters.t
+++ b/t/model-with-filters.t
@@ -1,6 +1,7 @@
 use Agrammon::DataSource::CSV;
 use Agrammon::Model;
 use Agrammon::Model::Parameters;
+use Agrammon::Outputs::FilterGroupCollection;
 use Agrammon::TechnicalParser;
 
 use Test;
@@ -89,6 +90,15 @@ subtest 'Running the model produces output instances with filters' => {
         given @results-by-group.grep(*.key eqv {"Livestock::Pig::Excretion::animalcategory" => "boars"}) {
             is .elems, 1, 'Found filter group value for boars';
             is .[0].value, <238158/10625>, 'Correct value calculated for boars';
+            given translate-filter-keys($model, .[0].key) -> %translated {
+                is %translated.elems, 1, 'Translated filter key hash has one element';
+                is-deeply %translated.keys[0],
+                    {:de("Tierkategorie"), :en("Animal category"), :fr("Catégorie d'animaux")},
+                    'Correct translation of key';
+                is-deeply %translated.values[0],
+                    {:de("Eber"), :en("boars"), :fr("Verrats"), :it("boars")},
+                    'Correct translation of value';
+            }
         }
         my @all-results-by-group = $livestock-tan.results-by-filter-group(:all);
         given @all-results-by-group[0] {


### PR DESCRIPTION
This provides a means to take a filter key and get the translations for both labels and values. It returns a `Hash[Hash,Hash]` - that is, an object hash where the key is the labels translation hash from the input, and the value is the translation hash of the enum value. JSON can't represent a hash with object keys, so a choice will need to be made on how to send those to the frontend; I didn't do that bit, as it's probably easier done with a frontend change.

Also, removed some dead code.