### PR TITLE
Add correct labels to reports inlc. translations

### DIFF
--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Application.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Application.nhd
@@ -47,9 +47,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = LivestockNtot
   ++labels
     sort = 675
-    en = __liquid
-    de = ?
-    fr = ?
+    en = __Liquid
+    de = __Flüssig
+    fr = __Liquides
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -64,9 +64,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = LivestockNtot
   ++labels
     sort = 685
-    en = __solid
-    de = ?
-    fr = ?
+    en = __Solid
+    de = __Fest
+    fr = __Solides
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -82,8 +82,8 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   ++labels
     sort = 670
     en = Into application
-    de = ?
-    fr = ?
+    de = In Ausbringung
+    fr = Dans l'épandage
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -105,9 +105,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = LivestockTAN
   ++labels
     sort = 875
-    en = __liquid
-    de = ?
-    fr = ?
+    en = __Liquid
+    de = __Flüssig
+    fr = __Liquides
   ++units  
     en = kg TAN/year
     de = kg TAN/Jahr
@@ -122,9 +122,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = LivestockTAN
   ++labels
     sort = 885
-    en = __solid
-    de = ?
-    fr = ?
+    en = __Solid
+    de = __Fest
+    fr = __Solides
   ++units  
     en = kg TAN/year
     de = kg TAN/Jahr
@@ -140,8 +140,8 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   ++labels
     sort = 870
     en = Into application
-    de = ?
-    fr = ?
+    de = In Ausbringung
+    fr = Dans l'épandage
   ++units  
     en = kg TAN/year
     de = kg TAN/Jahr
@@ -164,9 +164,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = SummaryLivestock,LivestockNH3
   ++labels 
     sort = 085
-    en = __NH3-Emissions from solid manure application
-    de = __Hofdüngerausbringung fest NH3-Emission
-    fr = __Emission de NH3 Epandage des engrais de ferme solides
+    en = __Solid
+    de = __Fest
+    fr = __Solides
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -185,9 +185,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = SummaryLivestock,LivestockNH3
   ++labels 
     sort = 075
-    en = __NH3-Emissions from liquid manure application
-    de = __Hofdüngerausbringung flüssig NH3-Emission
-    fr = __Emission de NH3 Epandage des engrais de ferme liquides
+    en = __Liquid
+    de = __Flüssig
+    fr = __Liquides
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -202,9 +202,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = SummaryLivestock,LivestockNH3
   ++labels 
     sort = 070
-    en = NH3-Emissions from manure application
-    de = Hofdüngerausbringung NH3-Emission
-    fr = Emission de NH3 Epandage des engrais de ferme
+    en = Application
+    de = Hofdüngerausbringung
+    fr = Epandage
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -348,9 +348,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = LivestockN2O
   ++labels 
     sort = 370
-    en = N2O-Emissions from manure application
-    de = Hofdüngerausbringung N2O-Emission
-    fr = Emission de N2O Epandage des engrais de ferme
+    en = Application
+    de = Hofdüngerausbringung
+    fr = Epandage
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -374,9 +374,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = LivestockNtot
   ++labels
     sort = 691
-    en = __liquid
-    de = ?
-    fr = ?
+    en = __Liquid
+    de = __Flüssig
+    fr = __Liquides
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -395,9 +395,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = LivestockNtot
   ++labels
     sort = 692
-    en = __solid
-    de = ?
-    fr = ?
+    en = __Solid
+    de = __Fest
+    fr = __Solides
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -417,8 +417,8 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   ++labels
     sort = 690
     en = Into soil from application
-    de = ?
-    fr = ?
+    de = In Boden von Ausbringung
+    fr = Dans le sol suite à l'épandage
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -441,9 +441,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = LivestockTAN
   ++labels
     sort = 891
-    en = __liquid
-    de = ?
-    fr = ?
+    en = __Liquid
+    de = __Flüssig
+    fr = __Liquides
   ++units  
     en = kg TAN/year
     de = kg TAN/Jahr
@@ -462,9 +462,9 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   print = LivestockTAN
   ++labels
     sort = 892
-    en = __solid
-    de = ?
-    fr = ?
+    en = __Solid
+    de = __Fest
+    fr = __Solides
   ++units  
     en = kg TAN/year
     de = kg TAN/Jahr
@@ -484,8 +484,8 @@ gui      = Application,Hofdüngerausbringung,Epandage,Application
   ++labels
     sort = 890
     en = Into soil from application
-    de = ?
-    fr = ?
+    de = In Boden von Ausbringung
+    fr = Dans le sol suite à l'épandage
   ++units  
     en = kg TAN/year
     de = kg TAN/Jahr

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/End.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/End.nhd
@@ -48,42 +48,42 @@ Dummy Module marking the startpoint for the Model Parser
   +DetailReport
     type = reportDetailed
     ++selector
-      en = TODO: Detail Report
-      de = TODO: Detail Report
-      fr = TODO: Detail Report
+      en = Emissions and fluxes (in kg N per year) - detailed report
+      de = Emissionen und Flüsse (in kg N pro Jahr) - detaillierte Zusammenfassung
+      fr = Emissions et flux d'azote (en kg de N par année) - résumé detaillé
     ++data
        +++LivestockNH3
-         en = Livestock NH3-Emissions
-         de = NH3 Emissionen Tierproduktion
-         fr = TODO: ?
+         en = Livestock production NH3-Emissions
+         de = Tierproduktion NH3-Emissionen
+         fr = Production animale Emissions de NH3 
        +++PlantNH3
          en = Plant production NH3-Emissions
-         de = NH3 Emissionen Pflanzenbau
-         fr = TODO: ?
+         de = Pflanzenbau NH3-Emissionen
+         fr = Production végétale Emissions de NH3
       +++SummaryTotal
         en = Total NH3-Emissions
-        de = NH3 Emissionen Total
-        fr = TODO: ?
+        de = Total NH3-Emissionen
+        fr = Totales Emissions de NH3 
       +++LivestockN2O
-        en = Livestock N2O-Emissions
-        de = N2O Emissionen Tierproduktion
-        fr = TODO: ?
+        en = Livestock production N2O-Emissions
+        de = Tierproduktion N2O-Emissionen
+        fr = Production animale Emissions de N2O
       +++LivestockNO
-        en = Livestock NO-Emissions
-        de = NO Emissionen Tierproduktion
-        fr = TODO: ?
+        en = Livestock production NO-Emissions
+        de = Tierproduktion NO-Emissionen
+        fr = Production animale Emissions de NO
       +++LivestockN2
-        en = Livestock N2-Emissions
-        de = N2 Emissionen Tierproduktion
-        fr = TODO: ?
+        en = Livestock production N2-Emissions
+        de = Tierproduktion N2-Emissionen
+        fr = Production animale Emissions de N2
       +++LivestockNtot
-        en = Flux total nitrogen livestock
-        de = Ntot Fluss Tierproduktion
-        fr = TODO: ?
+        en = Nitrogen flux livestock production
+        de = Stickstofffluss Tierproduktion
+        fr = Flux d'azote production animale
       +++LivestockTAN
-        en = Flux TAN livestock
+        en = TAN flux livestock production
         de = TAN Fluss Tierproduktion
-        fr = TODO: ?
+        fr = Flux de TAN production animale
 ?endif
 
 

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Livestock.nhd
@@ -155,7 +155,7 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
     sort = 630
     en = __Housing
     de = __Stall
-    fr = __?
+    fr = __Stabulation
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -179,7 +179,7 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
     sort = 640
     en = __Yard
     de = __Laufhof
-    fr = __?
+    fr = __Parcours extérieur
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -197,8 +197,8 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   ++labels
     sort = 620
     en = Into housing and exercise yard
-    de = Total N Ausscheidung
-    fr = Excrétion de N totale
+    de = In Stall und Laufhof
+    fr = Dans la stabulation et le parcours extérieur
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -215,8 +215,8 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   ++labels
     sort = 610
     en = Into grazing
-    de = Total N Ausscheidung
-    fr = Excrétion de N totale
+    de = In Weide
+    fr = Dans le pâturage
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -743,9 +743,9 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   print = SummaryLivestock,LivestockNH3
   ++labels
     sort = 010
-    en = Grazing NH3-Emissions
-    de = Weide NH3-Emission
-    fr = Emission de NH3 issu du pâturage
+    en = Grazing
+    de = Weide
+    fr = Pâturage
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -767,9 +767,9 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   print = LivestockNH3
   ++labels
     sort = 030
-    en = __Housing NH3-Emissions
-    de = __NH3-Emission aus Stall
-    fr = __Emission de NH3 issu de la stabulation
+    en = __Housing
+    de = __Stall
+    fr = __Stabulation
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -791,9 +791,9 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   print = LivestockNH3
   ++labels
     sort = 040
-    en = __Yard NH3-Emissions
-    de = __NH3-Emission aus Laufhof
-    fr = __Emission de NH3 issu du parcours extérieur
+    en = __Yard
+    de = __Laufhof
+    fr = __Parcours extérieur
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -811,9 +811,9 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   print = SummaryLivestock,LivestockNH3
   ++labels
     sort = 020
-    en = Housing and Yard NH3-Emissions
-    de = Stall und Laufhof NH3-Emission
-    fr = Emission de NH3 issu de la stabulation et du parcours extérieur
+    en = Housing and Yard
+    de = Stall und Laufhof
+    fr = Stabulation et parcours extérieur
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -885,9 +885,9 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   print = LivestockN2
   ++labels
     sort = 520
-    en = Total N2-Emissions Housing, Yard and Storage
-    de = Total N2-Emission Stall, Laufhof und Lager
-    fr = Emission de N2 totale issue de la production animale
+    en = Housing, yard and storage
+    de = Stall, Laufhof und Lager
+    fr = Stabulation, parcours extérieur et stockage
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -944,9 +944,9 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   print = LivestockNO
   ++labels
     sort = 420
-    en = Total NO-Emissions Housing, Yard and Storage
-    de = Total NO-Emission Stall, Laufhof und Lager
-    fr = Emission de NO totale issue de la production animale
+    en = Housing, yard and storage
+    de = Stall, Laufhof und Lager
+    fr = Stabulation, parcours extérieur et stockage
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -1002,9 +1002,9 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   print = LivestockN2O
   ++labels
     sort = 320
-    en = Total N2O-Emissions Housing, Yard and Storage
-    de = Total N2O-Emission Stall, Laufhof und Lager
-    fr = Emission de N2O totale issue de la production animale
+    en = Housing, yard and storage
+    de = Stall, Laufhof und Lager
+    fr = Stabulation, parcours extérieur et stockage
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -1028,9 +1028,9 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   print = LivestockN2
   ++labels
     sort = 510
-    en = Grazing N2-Emissions
-    de = Weide N2-Emission
-    fr = Emission de N2 issu du pâturage
+    en = Grazing
+    de = Weide
+    fr = Pâturage
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -1052,9 +1052,9 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   print = LivestockNO
   ++labels
     sort = 410
-    en = Grazing NO-Emissions
-    de = Weide NO-Emission
-    fr = Emission de NO issu du pâturage
+    en = Grazing
+    de = Weide
+    fr = Pâturage
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -1077,9 +1077,9 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   print = LivestockN2O
   ++labels
     sort = 310
-    en = Grazing N2O-Emissions
-    de = Weide N2O-Emission
-    fr = Emission de N2O issu du pâturage
+    en = Grazing
+    de = Weide
+    fr = Pâturage
   ++units
     en = kg N/year
     de = kg N/Jahr
@@ -1101,9 +1101,9 @@ gui      = Livestock,Tierhaltung,Production animale,Livestock
   print = LivestockNtot
   ++labels
     sort = 694
-    en = Into soil rom grazing
-    de = ?
-    fr = ?
+    en = Into soil from grazing
+    de = In boden von Weide
+    fr = Dans le sol suite au pâturage
   ++units
     en = kg N/year
     de = kg N/Jahr

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/PlantProduction.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/PlantProduction.nhd
@@ -27,12 +27,12 @@ gui      = PlantProduction,Pflanzenbau,Production végétale,Plant production
 
 +nh3_nplantproduction
   format= %.0f
-  print = SummaryTotal,PlantNH3
+  print = SummaryPlantProduction,PlantNH3
   ++labels 
-    sort = 1199
-    en = Total Plantproduction NH3-Emissions
-    de = Total Pflanzenproduktion NH3-Emission
-    fr = Emission de NH3 Total Production végétale
+    sort = 199
+    en = Total
+    de = Total
+    fr = Total
   ++units  
     en = kg N/year
     de = kg N/Jahr

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/PlantProduction/MineralFertiliser.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/PlantProduction/MineralFertiliser.nhd
@@ -1251,9 +1251,9 @@ gui	     = PlantProduction::MineralFertiliser,Pflanzenbau::Mineralische Sticksto
    print = SummaryPlantProduction,PlantNH3
   ++labels
     sort = 110
-      en = Mineral fertiliser NH3-Emissions
-      de = Mineralischer Stickstoffdünger NH3-Emission
-      fr = Emission de NH3 engrais azotés minéraux 
+      en = Mineral fertiliser
+      de = Mineralischer Dünger
+      fr = Engrais minéral 
   ++units  
       en = kg N/year
       de = kg N/Jahr

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/PlantProduction/RecyclingFertiliser.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/PlantProduction/RecyclingFertiliser.nhd
@@ -174,9 +174,9 @@ Vanderweerden and Jarvis (1997)
   print = SummaryPlantProduction,PlantNH3
   ++labels 
     sort = 120
-    en = Recycling fertiliser NH3-Emissions
-    de = Recyclingdünger NH3-Emission
-    fr = Emission de NH3 Engrais de recyclage
+    en = Recycling fertiliser
+    de = Recyclingdünger
+    fr = Engrais de recyclés
   ++units  
     en = kg N/year
     de = kg N/Jahr

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Storage.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Storage.nhd
@@ -94,7 +94,7 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
     sort = 867
     en = Mineralization (liquid)
     de = Mineralisierung (flüssig)
-    fr = ?
+    fr = Minéralisation (liquide)
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -123,9 +123,9 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
   print = LivestockNtot
   ++labels
     sort = 655
-    en = __liquid
-    de = __?
-    fr = __?
+    en = __Liquid
+    de = __Flüssig
+    fr = __Liquides
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -140,9 +140,9 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
   print = LivestockNtot
   ++labels
     sort = 665
-    en = __solid
-    de = __?
-    fr = __?
+    en = __Solid
+    de = __Fest
+    fr = __Solides
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -160,10 +160,10 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
   format = %.0f
   print = LivestockNtot
   ++labels
-    sort = 667
-    en = Directly applied solid manure
-    de = __?
-    fr = __?
+    sort = 649
+    en = Without storage (directly applied)
+    de = Ohne Lagerung (direkt ausgebracht)
+    fr = Sans stockage (épandage directe)
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -180,8 +180,8 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
   ++labels
     sort = 650
     en = Into storage
-    de = ?
-    fr = ?
+    de = In Hofdüngerlager
+    fr = Dans le stockage
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -204,9 +204,9 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
   print = LivestockTAN
   ++labels
     sort = 855
-    en = __liquid
-    de = ?
-    fr = ?
+    en = __Liquid
+    de = __Flüssig
+    fr = __Liquides
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -221,9 +221,9 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
   print = LivestockTAN
   ++labels
     sort = 865
-    en = __solid
-    de = ?
-    fr = ?
+    en = __Solid
+    de = __Fest
+    fr = __Solides
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -242,9 +242,9 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
   print = LivestockTAN
   ++labels
     sort = 867
-    en = Directly applied solid manure
-    de = __?
-    fr = __?
+    en = Without storage (directly applied)
+    de = Ohne Lagerung (direkt ausgebracht)
+    fr = Sans stockage (épandage directe)
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -261,8 +261,8 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
   ++labels
     sort = 850
     en = Into storage
-    de = ?
-    fr = ?
+    de = In Hofdüngerlager
+    fr = Dans le stockage
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -406,9 +406,9 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
   print = SummaryLivestock,LivestockNH3
   ++labels 
     sort = 055
-    en = __Storage liquid NH3-Emissions
-    de = __Hofdüngerlagerung flüssig NH3-Emission
-    fr = __Emission de NH3 Stockage des engrais de ferme liquides 
+    en = __Liquid
+    de = __Flüssig
+    fr = __Liquides 
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -424,9 +424,9 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
   print = SummaryLivestock,LivestockNH3
   ++labels 
     sort = 065
-    en = __Storage solid NH3-Emissions
-    de = __Hofdüngerlagerung fest NH3-Emission
-    fr = __Emission de NH3 Stockage des engrais de ferme solides 
+    en = __Solid
+    de = __Fest
+    fr = __Solides 
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -445,9 +445,9 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
   print = SummaryLivestock,LivestockNH3
   ++labels 
     sort = 050
-    en = Storage NH3-Emissions
-    de = Hofdüngerlagerung NH3-Emission
-    fr = Emission de NH3 Stockage des engrais de ferme 
+    en = Storage
+    de = Hofdüngerlagerung
+    fr = Stockage
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -474,7 +474,7 @@ gui      = Storage,Hofdüngerlager,Stockage,Storage
     sort = 868
     en = Immobilization (solid)
     de = Immobilisierung (fest)
-    fr = ?
+    fr = Immobilisation (solide)
   ++units  
     en = kg N/year
     de = kg N/Jahr

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/Total.nhd
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/Total.nhd
@@ -25,12 +25,12 @@ taxonomy = Total
 
 +nh3_nanimalproduction
   format= %.0f
-  print = SummaryTotal,LivestockNH3
+  print = SummaryLivestock,LivestockNH3
   ++labels
-    sort = 1099
-    en = Total Animalproduction NH3-Emissions
-    de = Total Tierproduktion NH3-Emission
-    fr = Emission de NH3 Total Production animale
+    sort = 099
+    en = Total
+    de = Total
+    fr = Total
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -46,10 +46,10 @@ taxonomy = Total
   format= %.0f
   print = SummaryTotal
   ++labels
-    sort = 1299
-    en = Total NH3-Emissions
-    de = Total NH3-Emission
-    fr = Emission de NH3 Total
+    sort = 299
+    en = Total
+    de = Total
+    fr = Total
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -67,8 +67,8 @@ taxonomy = Total
   ++labels
     sort = 695
     en = Into soil total
-    de = ?
-    fr = ?
+    de = In Boden Total
+    fr = Total dans le sol
   ++units  
     en = kg N/year
     de = kg N/Jahr
@@ -85,8 +85,8 @@ taxonomy = Total
   ++labels
     sort = 895
     en = Into soil total
-    de = ?
-    fr = ?
+    de = In Boden Total
+    fr = Total dans le sol
   ++units  
     en = kg N/year
     de = kg N/Jahr


### PR DESCRIPTION
Add correct labels (incl. translations) and revert previous changes on sort arguments, i.e. change total sorting order back to the state of the currently released model.

Looks good now when running the local web version