### PR TITLE
Make export routes consistent

### DIFF
--- a/frontend/source/class/agrammon/module/output/Reports.js
+++ b/frontend/source/class/agrammon/module/output/Reports.js
@@ -181,7 +181,7 @@ qx.Class.define('agrammon.module.output.Reports', {
                 version      : version
             };
 
-            var url = '/get_excel_export';
+            var url = 'export/excel';
             if (baseUrl != null) {
                 url = baseUrl + url;
             }
@@ -230,7 +230,7 @@ qx.Class.define('agrammon.module.output.Reports', {
 //	        var variant = agrammon.Info.getInstance().getVariant();
             var version = agrammon.Info.getInstance().getVersion();
             var versionUrl   = 'version=' + version;
-            var url = 'export/latex'
+            var url = 'export/pdf'
                                + '?' + 'mode=public'
                                + '&' + reportUrl
                                + '&' + titleUrl

--- a/lib/Agrammon/Web/Routes.pm6
+++ b/lib/Agrammon/Web/Routes.pm6
@@ -240,7 +240,7 @@ sub api-routes (Str $schema, $ws) {
                 }
             }
         }
-        operation 'getExcelExport', -> LoggedIn $user {
+        operation 'exportExcel', -> LoggedIn $user {
             request-body -> %params {
                 response.append-header(
                         'Content-disposition',

--- a/share/agrammon.openapi
+++ b/share/agrammon.openapi
@@ -395,10 +395,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Error"
-    /get_excel_export:
+    /export/excel:
         post:
             summary: Get Excel export
-            operationId: getExcelExport
+            operationId: exportExcel
             requestBody:
                 required: true
                 content:


### PR DESCRIPTION
- Put Excel and Pdf export at same base URL
- Consistent naming
PDF-export frontend refactoring will follow with backend implementation.