### PR TITLE
Invalidate OutputCache on delete-instance

### DIFF
--- a/lib/Agrammon/Web/Service.pm6
+++ b/lib/Agrammon/Web/Service.pm6
@@ -271,6 +271,7 @@ class Agrammon::Web::Service {
 
     method delete-instance(Agrammon::Web::SessionUser $user, $dataset-name, $variable-pattern, $instance --> Nil) {
         Agrammon::DB::Dataset.new(:$user, :name($dataset-name)).delete-instance($variable-pattern, $instance);
+        $!outputs-cache.invalidate($user.username, $dataset-name);
     }
 
     method load-branch-data(Agrammon::Web::SessionUser $user, Str $name) {


### PR DESCRIPTION
- `store-data` isn't called when deleting instances, thus be must invalidate the cache explicitly here