### PR TITLE
Add sudo for admin and support users

### DIFF
--- a/frontend/source/class/agrammon/Application.js
+++ b/frontend/source/class/agrammon/Application.js
@@ -221,7 +221,7 @@ qx.Class.define('agrammon.Application', {
             var userData     = msg.getData();
             this.debug('__login(' + userData.user + ')');
             if (this.__supports_html5_storage() && userData.remember) {
-                localStorage.setItem('agrammonUsername', userData.user);
+                localStorage.setItem('agrammonUsername', userData.username);
                 localStorage.setItem('agrammonPassword', userData.password);
                 localStorage.setItem('agrammonRemember', userData.remember);
             }

--- a/frontend/source/class/agrammon/Application.js
+++ b/frontend/source/class/agrammon/Application.js
@@ -239,13 +239,11 @@ qx.Class.define('agrammon.Application', {
 
         __logoutFunc: function(data, exc, id) {
             if (exc == null || exc == 403) {
-                // TODO: implement sudo
-                console.log('data=', data);
                 if (data.sudoUser) {
                     var infoOnly = true;
                     var dialog = new agrammon.ui.dialog.Confirm(
                         this.tr("End change user"),
-                        this.tr("Returning from %1 to %2", data.sudoUser, data.user),
+                        this.tr("Returning from %1 to %2", data.sudoUser, data.username),
                         qx.lang.Function.bind(function() {
                             this.__authenticate(data, exc, id);
                             dialog.close()

--- a/frontend/source/class/agrammon/Application.js
+++ b/frontend/source/class/agrammon/Application.js
@@ -159,7 +159,7 @@ qx.Class.define('agrammon.Application', {
                     }
                     // enable admin menu
                     mainMenu.showAdmin(role == 'admin' || role == 'support');
-                    if (role != 'admin') { // TODO: fix update
+                    if (results && role != 'admin') { // TODO: fix update
                         results.exclude();
                     }
                     qx.event.message.Bus.dispatchByName('agrammon.DatasetCache.refresh', username);
@@ -239,8 +239,8 @@ qx.Class.define('agrammon.Application', {
 
         __logoutFunc: function(data, exc, id) {
             if (exc == null || exc == 403) {
-                this.__loginDialog.open();
                 // TODO: implement sudo
+                console.log('data=', data);
                 if (data.sudoUser) {
                     var infoOnly = true;
                     var dialog = new agrammon.ui.dialog.Confirm(

--- a/frontend/source/class/agrammon/Application.js
+++ b/frontend/source/class/agrammon/Application.js
@@ -134,14 +134,14 @@ qx.Class.define('agrammon.Application', {
 
             this.__authenticate = function(data, exc, id) {
                 if (exc == null) {
-                    var user      = data.user;
+                    var username  = data.username;
                     var role      = data.role;
                     var news      = data.news;
                     var lastLogin = String(data.last_login);
 
                     qx.event.message.Bus.dispatchByName(
                         'agrammon.info.setUser',
-                        { username : user, role : role }
+                        { username : username, role : role }
                     );
                     if (news && news != '') {
                         var dialog = new agrammon.ui.dialog.News(
@@ -162,7 +162,7 @@ qx.Class.define('agrammon.Application', {
                     if (role != 'admin') { // TODO: fix update
                         results.exclude();
                     }
-                    qx.event.message.Bus.dispatchByName('agrammon.DatasetCache.refresh', user);
+                    qx.event.message.Bus.dispatchByName('agrammon.DatasetCache.refresh', username);
                 }
                 else {
                     qx.event.message.Bus.dispatchByName('error',
@@ -224,6 +224,9 @@ qx.Class.define('agrammon.Application', {
                 localStorage.setItem('agrammonUsername', userData.username);
                 localStorage.setItem('agrammonPassword', userData.password);
                 localStorage.setItem('agrammonRemember', userData.remember);
+            }
+            if (userData.sudoUsername === undefined) {
+                userData.sudoUsername = null;
             }
             this.__rpc.callAsync( this.__authenticate, 'auth', userData);
         },

--- a/frontend/source/class/agrammon/Application.js
+++ b/frontend/source/class/agrammon/Application.js
@@ -137,7 +137,7 @@ qx.Class.define('agrammon.Application', {
                     var username  = data.username;
                     var role      = data.role;
                     var news      = data.news;
-                    var lastLogin = String(data.last_login);
+                    var lastLogin = String(data.lastLogin);
 
                     qx.event.message.Bus.dispatchByName(
                         'agrammon.info.setUser',

--- a/frontend/source/class/agrammon/module/user/Account.js
+++ b/frontend/source/class/agrammon/module/user/Account.js
@@ -335,12 +335,12 @@ qx.Class.define('agrammon.module.user.Account', {
         this.activateAccount = activateAccount;
 
         var login = function(e) {
-//            this.debug('login(): this='+this);
             var username    = this.user.getValue();
             var password    = this.password1.getValue().toLowerCase();
-            qx.event.message.Bus.dispatchByName('agrammon.main.login',
-                                          {'user':     username,
-                                           'password': password});
+            qx.event.message.Bus.dispatchByName(
+                'agrammon.main.login',
+                { username : username, password : password }
+            );
             this.close();
         };
         this.login = login;

--- a/frontend/source/class/agrammon/module/user/Login.js
+++ b/frontend/source/class/agrammon/module/user/Login.js
@@ -139,7 +139,7 @@ qx.Class.define('agrammon.module.user.Login', {
                     }
                 }
                 this.password.clearValue();
-                var sudoUser;
+                var sudoUser = null;
                 if (sudo) {
                     sudoUser = agrammon.Info.getInstance().getUserName();
                 }

--- a/frontend/source/class/agrammon/module/user/Login.js
+++ b/frontend/source/class/agrammon/module/user/Login.js
@@ -18,10 +18,12 @@ qx.Class.define('agrammon.module.user.Login', {
         this.setLayout(new qx.ui.layout.HBox(10));
 
         var that = this;
-        this.set({modal: true,
-                  showClose: false, showMinimize: false, showMaximize: false,
-                  caption: title
-                 });
+        this.set({
+            modal: true,
+            showClose: false, showMinimize: false, showMaximize: false,
+            centerOnAppear : true,
+            caption: title
+        });
 
         var leftBox =
             new qx.ui.container.Composite(new qx.ui.layout.VBox(10));
@@ -34,20 +36,16 @@ qx.Class.define('agrammon.module.user.Login', {
             this.add(rightBox);
         }
 
-        qx.locale.Manager.getInstance().addListener("changeLocale",
-                                                    this.__changeLanguage,
-                                                    this);
+        qx.locale.Manager.getInstance().addListener("changeLocale", this.__changeLanguage, this);
 
-        var user = new agrammon.ui.form.VarInput(this.tr("Username"), '', '', '', 'Enter username');
-        this.user = user;
+        var user = this.__user = new agrammon.ui.form.VarInput(this.tr("Username"), '', '', '', 'Enter username');
         leftBox.add(user);
         user.setPadding(5);
         user.setPaddingBottom(0);
 
-        var password = new agrammon.ui.form.VarPassword(this.tr("Password"));
+        var password = this.__password = new agrammon.ui.form.VarPassword(this.tr("Password"));
         password.setPadding(5);
         password.setPaddingTop(0);
-        this.password = password;
         if (!sudo) {
             leftBox.add(password);
         }
@@ -85,8 +83,8 @@ qx.Class.define('agrammon.module.user.Login', {
                                   "icon/16/actions/dialog-cancel.png");
 
         btnCancel.addListener("execute", function(e) {
-            this.user.clearValue();
-            this.password.clearValue();
+            this.__user.clearValue();
+            this.__password.clearValue();
             if (sudo) {
                 that.close();
             }
@@ -95,73 +93,50 @@ qx.Class.define('agrammon.module.user.Login', {
         // FIX ME: deal with sub locales
         var locale = qx.locale.Manager.getInstance().getLocale();
         locale = locale.replace(/_.+/,'');
-//        this.debug('Login: locale='+locale);
-        var help = new agrammon.ui.dialog.DocWindow(this.tr("Help"),
-                                             this.__baseUrl + 'doc/login.'
-                                             + locale + '.html');
-        this.help = help;
-        btnHelp.addListener("execute",
-            function(e) {
-                this.user.clearValue();
-                this.password.clearValue();
-                help.open();
-            },
-            this
+        var help = this.__help = new agrammon.ui.dialog.DocWindow(
+            this.tr("Help"),
+            this.__baseUrl + 'doc/login.' + locale + '.html'
         );
+        btnHelp.addListener("execute", function(e) {
+            this.__user.clearValue();
+            this.__password.clearValue();
+            help.open();
+        }, this);
 
-        btnOK.addListener("execute",
-            function(e) {
-                var username      = this.user.getValue();
-                var password      = this.password.getValue();
-                var remember = false;
-                if (that.supports_html5_storage() && !sudo) {
-                    remember = that.__remember.getValue();
+        btnOK.addListener("execute", function(e) {
+            var username = this.__user.getValue();
+            var password = this.__password.getValue();
+            var remember = false;
+            if (that.supports_html5_storage() && !sudo) {
+                remember = that.__remember.getValue();
+            }
+
+            this.__password.clearValue();
+            qx.event.message.Bus.dispatchByName(
+                'agrammon.main.login',
+                {
+                    username : username, password : password,
+                    remember : remember, sudo : sudo
                 }
-                
-                this.password.clearValue();
-                var sudoUser = null;
-                if (sudo) {
-                    sudoUser = agrammon.Info.getInstance().getUserName();
-                }
-                qx.event.message.Bus.dispatchByName(
-                    'agrammon.main.login',
-                    {
-                        username : username, password : password,
-                        remember : remember, sudoUsername : sudoUser
-                    }
-                );
-                this.close();
-            },
-           this
-        );
+            );
+            this.close();
+        }, this);
 
-        btnNew.addListener("execute",
-            function(e) {
-                this.debug('btNew: this='+this);
-                var username    = this.user.getValue();
-                var newDialog =
-                    new agrammon.module.user.Account(this.tr("Create new account"),
-                                                     username, 'userCreate');
-                newDialog.open();
-                this.password.clearValue();
-                this.close();
-            },
-           this
-        );
+        btnNew.addListener("execute", function(e) {
+            var username  = this.__user.getValue();
+            var newDialog = new agrammon.module.user.Account(this.tr("Create new account"), username, 'userCreate');
+            newDialog.open();
+            this.__password.clearValue();
+            this.close();
+        } ,this);
 
-        btnPassword.addListener("execute",
-            function(e) {
-                this.debug('btPassword: this='+this);
-                var username    = this.user.getValue();
-                var newDialog =
-                    new agrammon.module.user.Account(this.tr("Reset password"),
-                                                     username, 'reset');
-                newDialog.open();
-                this.password.clearValue();
-                this.close();
-            },
-           this
-        );
+        btnPassword.addListener("execute", function(e) {
+            var username  = this.__user.getValue();
+            var newDialog = new agrammon.module.user.Account(this.tr("Reset password"), username, 'reset');
+            newDialog.open();
+            this.__password.clearValue();
+            this.close();
+        }, this);
 
         bbox.add(btnCancel, {flex : 1});
         bbox.add(btnOK, {flex : 1});
@@ -170,7 +145,6 @@ qx.Class.define('agrammon.module.user.Login', {
         rightBox.add(btnPassword, {flex : 0});
         rightBox.add(btnNew, {flex : 0});
 
-        //  breaks internet explorer
         this.addListener('keydown', function(e) {
             if (e.getKeyIdentifier() == 'Enter') {
                 btnOK.execute();
@@ -190,8 +164,6 @@ qx.Class.define('agrammon.module.user.Login', {
         btnNew.setTabIndex(idx++);
 
         this.addListener('appear', function() {
-            this.center();
-            this.debug('login appear');
             var appUsername, appPassword, appRemember;
             if (this.supports_html5_storage()) {
                 appUsername = localStorage.getItem('agrammonUsername');
@@ -209,27 +181,27 @@ qx.Class.define('agrammon.module.user.Login', {
                 password.setValue(appPassword);
             }
 
-            if (user.getValue() != '' && password.getValue() != '') {
-                btnOK.focus();
+            if (!user.getValue()) {
+                user.focus();
             }
-            else if (user.getValue() != null) {
-                password.focus();
+            else if (!password.getValue()) {
+                password.getInputField().focus();
             }
             else {
-                user.focus();
+                btnOK.focus();
             }
 
         }, this);
 
-//        var root = qx.core.Init.getApplication().getRoot();
-//        this.open();
-//        root.add(this);
     }, // construct
 
     members :
     {
-        __rpc: null,
-        __baseUrl: null,
+        __rpc      : null,
+        __baseUrl  : null,
+        __user     : null,
+        __help     : null,
+        __password : null,
 
         supports_html5_storage: function() {
             try {
@@ -242,11 +214,9 @@ qx.Class.define('agrammon.module.user.Login', {
         __changeLanguage: function() {
             // FIX ME: deal with sub locales
             var locale = qx.locale.Manager.getInstance().getLocale();
-//            this.debug('Login: locale='+locale);
             locale = locale.replace(/_.+/,'');
             this.debug('Login: locale='+locale);
-            this.help.setSource(this.__baseUrl
-                                + 'doc/login.' + locale + '.html');
+            this.__help.setSource(this.__baseUrl + 'doc/login.' + locale + '.html');
         }
 
     }

--- a/frontend/source/class/agrammon/module/user/Login.js
+++ b/frontend/source/class/agrammon/module/user/Login.js
@@ -118,26 +118,6 @@ qx.Class.define('agrammon.module.user.Login', {
                     remember = that.__remember.getValue();
                 }
                 
-			    var userShortcuts = {
-                    'fz': 'fritz.zaucker@oetiker.ch',
-                    'rp': 'roman.plessl@oetiker.ch',
-                    'to': 'tobias@oetiker.ch',
-                    'mo': 'manuel@oetiker.ch',
-                    'hr': 'hr@bjengineering.ch',
-                    'cb': 'cyrill.bonjour@bjengineering.ch',
-                    'hm': 'harald.menzi@bfh.ch',
-                    'ba': 'beat.achermann@bafu.admin.ch',
-                    'cl': 'christian.leuenberger@leupro.ch',
-                    'an': 'aurelia.nyfeler@bjengineering.ch',
-                    'tk': 'thomas.kupper@bfh.ch',
-                    'fb': 'fritz.birrer@lu.ch'
-                };
-                for (var key in userShortcuts) {
-                    if (username == key) {
-                        username = userShortcuts[key];
-                        break;
-                    }
-                }
                 this.password.clearValue();
                 var sudoUser = null;
                 if (sudo) {

--- a/frontend/source/class/agrammon/module/user/Login.js
+++ b/frontend/source/class/agrammon/module/user/Login.js
@@ -143,12 +143,13 @@ qx.Class.define('agrammon.module.user.Login', {
                 if (sudo) {
                     sudoUser = agrammon.Info.getInstance().getUserName();
                 }
-                qx.event.message.Bus.dispatchByName('agrammon.main.login',
-                                              {'user':     username,
-                                               'password': password,
-                                               'remember': remember,
-                                               'sudoUser': sudoUser
-                                               });
+                qx.event.message.Bus.dispatchByName(
+                    'agrammon.main.login',
+                    {
+                        username : username, password : password,
+                        remember : remember, sudoUsername : sudoUser
+                    }
+                );
                 this.close();
             },
            this

--- a/frontend/source/class/agrammon/ui/menu/AdminMenu.js
+++ b/frontend/source/class/agrammon/ui/menu/AdminMenu.js
@@ -40,23 +40,19 @@ qx.Class.define('agrammon.ui.menu.AdminMenu', {
         },
 
         __createAccount: function() {
-             var newDialog =
-                 new agrammon.module.user.Account(this.tr("Create account"),
-                                                  null, 'adminCreate');
+             var newDialog = new agrammon.module.user.Account(this.tr("Create account"), null, 'adminCreate');
             newDialog.open();
         },
 
         __resetPassword: function() {
             var newDialog =
-                new agrammon.module.user.Account(this.tr("Reset password"),
-                                                 null, 'adminReset');
+                new agrammon.module.user.Account(this.tr("Reset password"), null, 'adminReset');
             newDialog.open();
         },
 
         __sudo: function() {
             var sudo = true;
-            var loginDialog =
-                new agrammon.module.user.Login(this.tr("Change to user account"), sudo);
+            var loginDialog = new agrammon.module.user.Login(this.tr("Change to user account"), sudo);
             loginDialog.open();
         }
 

--- a/lib/Agrammon/DB/User.pm6
+++ b/lib/Agrammon/DB/User.pm6
@@ -48,6 +48,13 @@ class X::Agrammon::DB::User::UnknownUser is Exception {
     }
 }
 
+class X::Agrammon::DB::User::MayNotSudo is Exception {
+    has Str $.username is required;
+    method message() {
+        "User '$!username' may not change to another account";
+    }
+}
+
 class X::Agrammon::DB::User::PasswordsIdentical is Exception {
     method message() {
         "Old and new password must be different";

--- a/lib/Agrammon/Web/Routes.pm6
+++ b/lib/Agrammon/Web/Routes.pm6
@@ -460,7 +460,7 @@ sub application-routes(Agrammon::Web::Service $ws) {
 
         # TODO: implement news in auth()
         post -> Agrammon::Web::SessionUser $user, 'auth' {
-            request-body -> :$username, :$password, :sudoUsername($sudo-username) {
+            request-body -> (:$username, :$password, :sudoUsername($sudo-username)) {
                 if $user.auth($username, $password, $sudo-username) {
                     content 'application/json', %(
                         :$username,

--- a/lib/Agrammon/Web/Routes.pm6
+++ b/lib/Agrammon/Web/Routes.pm6
@@ -465,7 +465,7 @@ sub application-routes(Agrammon::Web::Service $ws) {
                     content 'application/json', %(
                         :$username,
                         :role($user.role.name),
-                        :last_login($user.last-login),
+                        :lastLogin($user.last-login),
                         :news(Nil),
                         :sudoUser($user.sudo-user),
                     );

--- a/lib/Agrammon/Web/Routes.pm6
+++ b/lib/Agrammon/Web/Routes.pm6
@@ -460,16 +460,14 @@ sub application-routes(Agrammon::Web::Service $ws) {
 
         # TODO: implement news in auth()
         post -> Agrammon::Web::SessionUser $user, 'auth' {
-            request-body -> %data {
-                my $username = %data<user>;
-                my $password = %data<password>;
-                if $user.auth($username, $password) {
+            request-body -> :$username, :$password, :sudoUsername($sudo-username) {
+                if $user.auth($username, $password, $sudo-username) {
                     content 'application/json', %(
-                        user       => $username,
-                        role       => $user.role.name,
-                        last_login => $user.last-login,
-                        news       => Nil,
-                        :!sudoUser,
+                        :$username,
+                        :role($user.role.name),
+                        :last_login($user.last-login),
+                        :news(Nil),
+                        :sudoUser($user.sudo-user),
                     );
                 }
                 CATCH {

--- a/lib/Agrammon/Web/Routes.pm6
+++ b/lib/Agrammon/Web/Routes.pm6
@@ -460,7 +460,7 @@ sub application-routes(Agrammon::Web::Service $ws) {
 
         # TODO: implement news in auth()
         post -> Agrammon::Web::SessionUser $user, 'auth' {
-            request-body -> (:$username, :$password, :sudoUsername($sudo-username)) {
+            request-body -> (:$username, :$password, :sudoUsername($sudo-username), *%rest) {
                 if $user.auth($username, $password, $sudo-username) {
                     content 'application/json', %(
                         :$username,

--- a/lib/Agrammon/Web/Routes.pm6
+++ b/lib/Agrammon/Web/Routes.pm6
@@ -449,19 +449,14 @@ sub application-routes(Agrammon::Web::Service $ws) {
             content 'application/json', %cfg;
         }
 
-        # working
-        post -> Agrammon::Web::SessionUser $user, 'logout' {
-            $user.logout();
-            content 'application/json', %(
-                :user($user.username),
-                :!sudoUser,
-            );
-        }
-
         # TODO: implement news in auth()
         post -> Agrammon::Web::SessionUser $user, 'auth' {
-            request-body -> (:$username, :$password, :sudoUsername($sudo-username), *%rest) {
+            request-body -> (:$username, :$password, :$sudo, *%rest) {
+                note "sudo=", ($sudo // 'UNDEF');
+                my $sudo-username = $user.username if $user.logged-in && $sudo;
+                note "Routes1: sudo-username=", ($sudo-username // 'UNDEF');
                 if $user.auth($username, $password, $sudo-username) {
+                    note "Routes2: sudo-username=", ($sudo-username // 'UNDEF');
                     content 'application/json', %(
                         :$username,
                         :role($user.role.name),
@@ -479,7 +474,18 @@ sub application-routes(Agrammon::Web::Service $ws) {
             }
         }
 
-        # working
+        post -> LoggedIn $user, 'logout' {
+            dd $user;
+            my $sudo-username = $user.sudo-username;
+            note "Routes.logout: sudo-username=", ($sudo-username // 'UNDEF');
+            $user.logout();
+            content 'application/json', %(
+                :user($user.username),
+                :sudoUser($sudo-username),
+            );
+        }
+
+        # TODO: test
         post -> LoggedIn $user, 'load_branch_data' {
             request-body -> (:datasetName($dataset-name), :%data!) {
                 my $data = $ws.load-branch-data($user, $dataset-name, %data);

--- a/lib/Agrammon/Web/SessionUser.pm6
+++ b/lib/Agrammon/Web/SessionUser.pm6
@@ -4,14 +4,11 @@ use Agrammon::DB::User;
 
 class Agrammon::Web::SessionUser is Agrammon::DB::User does Cro::HTTP::Auth {
     has Bool $.logged-in = False;
-    has Bool $.sudo-user = False;
-    has Str  $.sudo-username;
+    has Str $.sudo-username;
 
     method auth($username, $password, $sudo-username?) {
         if $sudo-username {
             die X::Agrammon::DB::User::MayNotSudo.new(:username($sudo-username)) unless self.may-sudo;
-
-            $!sudo-user = True;
             $!sudo-username = $sudo-username;
         }
         else {
@@ -21,33 +18,34 @@ class Agrammon::Web::SessionUser is Agrammon::DB::User does Cro::HTTP::Auth {
 
         self.set-username($username);
         self.load;
-        note "SessionUser: sudo-username=", ($!sudo-username // 'UNDEF');
         return self;
     }
 
     method logout() {
-        note "SessionUser.logout: sudo-username=", ($!sudo-username // 'UNDEF'), ', sudo-user=', ($!sudo-username // 'UNDEF');
-        if $!sudo-user {
+        my $old-username;
+        if $!sudo-username {
+            $old-username = self.username;
             self.set-username($!sudo-username);
             self.load;
-            note "   Clearing sudo-user and sudo-username";
             $!sudo-username = Nil;
-            $!sudo-user = False;
         }
         else {
             $!logged-in = False;
         }
-    }
-
-    method to-json() {
-        { :$!logged-in, :$.username }
-    }
-
-    method from-json((:$logged-in = False, :$username = Str)) {
-        self.new(:$logged-in, :$username).load
+        return $old-username;
     }
 
     method may-sudo {
         return $!logged-in and self.role.name eq 'admin' | 'support';
     }
+
+    # Add what's needed to be persisted to database
+    method to-json() {
+        { :$!logged-in, :$.username, |(:$!sudo-username if $!sudo-username) }
+    }
+
+    method from-json((:$logged-in = False, :$username = Str, :$sudo-username = Str)) {
+        self.new(:$logged-in, :$username, :$sudo-username).load
+    }
+
 }

--- a/lib/Agrammon/Web/SessionUser.pm6
+++ b/lib/Agrammon/Web/SessionUser.pm6
@@ -36,7 +36,7 @@ class Agrammon::Web::SessionUser is Agrammon::DB::User does Cro::HTTP::Auth {
     }
 
     method may-sudo {
-        return $!logged-in and self.role.name eq 'admin' | 'support';
+        return $!logged-in && self.role.name eq 'admin' | 'support';
     }
 
     # Add what's needed to be persisted to database

--- a/t/routes-application.t
+++ b/t/routes-application.t
@@ -1,5 +1,6 @@
 use v6;
 
+use Agrammon::DB::Role;
 use Agrammon::Web::Routes;
 use Agrammon::Web::Service;
 use Agrammon::Web::SessionUser;
@@ -16,11 +17,11 @@ plan 15;
 sub make-fake-auth($role) {
     mocked(
         Agrammon::Web::SessionUser,
-        returning => { :id(42), :logged-in, :username('username') }
+        returning => { :id(42), :logged-in, :username('username'), :$role }
     )
 }
 
-my $role = 'user';
+my $role = Agrammon::DB::Role.new(:name('user'));
 my $fake-auth = make-fake-auth($role);
 
 my $fake-store = mocked(Agrammon::Web::Service,
@@ -252,7 +253,7 @@ subtest 'Logout' => {
     test-service routes($fake-store), :$fake-auth, {
         test post('/logout'),
                 status => 200,
-                json   => { :user('username'), :!sudoUser };
+                json   => { :username('username'), :role('user'),  :sudoUser(Any) }
     }
 }
 

--- a/t/user.t
+++ b/t/user.t
@@ -113,8 +113,8 @@ transactionally {
         subtest "login $username" => {
             ok $session-user = Agrammon::Web::SessionUser.new(:$username).load,
                 "Create Agrammon::Web::SessionUser with username $username";
-            ok $session-user.may-sudo, "$username may change account";
             ok $session-user.auth($username, $password).logged-in, "$username was authenticated with $password";
+            ok $session-user.may-sudo, "$username may change account";
             is $session-user.username, $username, "Username is $username";
             is $session-user.id, $uid, "Uid is $uid";
         }
@@ -132,7 +132,7 @@ transactionally {
         }
 
         subtest "logout $username2, back to $username" => {
-            ok !$session-user.logout, "Logout $username2";
+            is $session-user.logout, $username2, "Logout $username2 returns old username";
             ok $session-user.logged-in, "$username is logged in";
             is $session-user.username, $username, "Username is $username";
             is $session-user.id, $uid, "Uid is $uid";


### PR DESCRIPTION
- Users with role `admin` or `support` may sudo to another account
- Upon logout after a sudo the old login is restored