### PR TITLE
Use rakudo-2020.12 in GitHub actions

### DIFF
--- a/.github/workflows/backend-and-models.yml
+++ b/.github/workflows/backend-and-models.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-latest
         raku-version:
-          - '2020.11'
+          - '2020.12'
     runs-on: ${{ matrix.os }}
 
     services:


### PR DESCRIPTION
Use the same rakudo version as locally.