### PR TITLE
Basic integration of Cro::APIToken for providing an API

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -11,6 +11,7 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 --
 -- Name: dataset_name2id(text, text); Type: FUNCTION; Schema: public; Owner: agrammon

--- a/dev/META6.json
+++ b/dev/META6.json
@@ -75,6 +75,7 @@
     "Agrammon::Preprocessor": "lib/Agrammon/Preprocessor.pm6",
     "Agrammon::UI::CommandLine": "lib/Agrammon/UI/CommandLine.pm6",
     "Agrammon::UI::Web": "lib/Agrammon/UI/Web.pm6",
+    "Agrammon::Web::APIRoutes": "lib/Agrammon/Web/APIRoutes.pm6",
     "Agrammon::Web::APITokenManager": "lib/Agrammon/Web/APITokenManager.pm6",
     "Agrammon::Web::Routes": "lib/Agrammon/Web/Routes.pm6",
     "Agrammon::Web::Service": "lib/Agrammon/Web/Service.pm6",

--- a/dev/META6.json
+++ b/dev/META6.json
@@ -75,6 +75,7 @@
     "Agrammon::Preprocessor": "lib/Agrammon/Preprocessor.pm6",
     "Agrammon::UI::CommandLine": "lib/Agrammon/UI/CommandLine.pm6",
     "Agrammon::UI::Web": "lib/Agrammon/UI/Web.pm6",
+    "Agrammon::Web::APITokenManager": "lib/Agrammon/Web/APITokenManager.pm6",
     "Agrammon::Web::Routes": "lib/Agrammon/Web/Routes.pm6",
     "Agrammon::Web::Service": "lib/Agrammon/Web/Service.pm6",
     "Agrammon::Web::SessionStore": "lib/Agrammon/Web/SessionStore.pm6"

--- a/dev/META6.json
+++ b/dev/META6.json
@@ -26,7 +26,9 @@
     "Shell::Command",
     "Spreadsheet::XLSX:ver<0.2.2+>",
     "Text::CSV",
-    "YAMLish"
+    "YAMLish",
+    "Cro::APIToken",
+    "Cro::APIToken::Store::Pg"
   ],
   "build-depends": [],
   "test-depends": [

--- a/etc/agrammon.yaml.dist
+++ b/etc/agrammon.yaml.dist
@@ -3,6 +3,7 @@ General:
     log_file:   /tmp/agrammon.log
     log_level:  warn
     mojo_secret: MyCookieSecret
+    translationDir: share/translations
 
 Database:
     name:     agrammon_test

--- a/lib/Agrammon/Web/APIRoutes.pm6
+++ b/lib/Agrammon/Web/APIRoutes.pm6
@@ -1,0 +1,41 @@
+use Cro::APIToken::Middleware;
+use Cro::HTTP::Router;
+use Cro::OpenAPI::RoutesFromDefinition;
+
+use Agrammon::DB::User;
+use Agrammon::Web::APITokenManager;
+use Agrammon::Web::Service;
+
+#| API session object, which is just a subclass of the Agrammon user object.
+#| Since API requests are stateless, no further details are needed.
+my class APIUser is Agrammon::DB::User does Cro::HTTP::Auth {
+}
+
+#| Extends the Cro::APIToken middleware to load the Agrammon user as identified
+#| by the metadata associated with the API token.
+my class AgrammonAPITokenMiddleware does Cro::APIToken::Middleware {
+    method on-valid(Cro::HTTP::Request $request, Cro::APIToken::Token $token --> Cro::HTTP::Message) {
+        say "called on-valid";
+        with $token.metadata<username> -> $username {
+            my $api-user = APIUser.new(:$username);
+            if $api-user.exists {
+                $api-user.load;
+                $request.auth = $api-user;
+            }
+        }
+        return $request;
+    }
+}
+
+sub api-routes(Agrammon::Web::Service $ws) is export {
+    route {
+        before AgrammonAPITokenMiddleware.new(manager => get-api-token-manager());
+
+        get -> APIUser $user, 'greet' {
+            content 'application/json', { message => "Hello $user.firstname()" }
+        }
+    }
+}
+
+
+

--- a/lib/Agrammon/Web/APITokenManager.pm6
+++ b/lib/Agrammon/Web/APITokenManager.pm6
@@ -1,0 +1,13 @@
+use Cro::APIToken::Manager;
+use Cro::APIToken::Store::Pg;
+
+my $manager;
+
+#| Obtain the API token manager configured for Agrammon.
+sub get-api-token-manager(--> Cro::APIToken::Manager) is export {
+    $manager //= Cro::APIToken::Manager.new:
+            :40bytes, :prefix<agm>, :checksum,
+            store => Cro::APIToken::Store::Pg.new(
+                :handle($*AGRAMMON-DB-CONNECTION),
+                :table-name<api_tokens> :create-table)
+}

--- a/lib/Agrammon/Web/Routes.pm6
+++ b/lib/Agrammon/Web/Routes.pm6
@@ -4,7 +4,6 @@ use Cro::HTTP::Router;
 use Cro::OpenAPI::RoutesFromDefinition;
 use Cro::Uri :decode-percents;
 
-use Agrammon::Web::APIRoutes;
 use Agrammon::DB::Dataset;
 use Agrammon::DB::User;
 use Agrammon::Timestamp;

--- a/lib/Agrammon/Web/Routes.pm6
+++ b/lib/Agrammon/Web/Routes.pm6
@@ -4,6 +4,7 @@ use Cro::HTTP::Router;
 use Cro::OpenAPI::RoutesFromDefinition;
 use Cro::Uri :decode-percents;
 
+use Agrammon::Web::APIRoutes;
 use Agrammon::DB::Dataset;
 use Agrammon::DB::User;
 use Agrammon::Timestamp;
@@ -32,7 +33,7 @@ sub routes(Agrammon::Web::Service $ws) is export {
             }
         }
         include static-content($root);
-        include api-routes($schema, $ws);
+        include frontend-api-routes($schema, $ws);
         include dataset-routes($ws);
         include application-routes($ws);
         after {
@@ -113,7 +114,7 @@ sub static-content($root) {
     }
 }
 
-sub api-routes (Str $schema, $ws) {
+sub frontend-api-routes (Str $schema, $ws) {
     openapi $schema.IO, {
         # working
         operation 'createAccount', -> LoggedIn $user {


### PR DESCRIPTION
This is the minimal integration, and can be expanded on from here. It adds:

* A CLI command tool to issue an API token to a user (I didn't fill out the revoke and so forth tools one may want, but added this one as I needed it anyway)
* An implementation of the `Cro::APIToken::Middleware` role that uses the API token metadata to load an appropriate Agrammon user and set it into the request `auth` property
* An example API route

I reworked the routes and middleware application a little to make sure we don't spit out session cookies to API users. Since I didn't have to really run Agrammon for a while with a database, I had to set that up, and also patched a couple of small things that made life a little harder for me than it might have been, and will hopefully ease the way in future setups.

Note that the CI will likely fail as `Cro::APIToken` and `Cro::APIToken::Store::Pg` were only just released to CPAN, and it needs a bit of indexing time.