### PR TITLE
Implement input validation against the model

### DIFF
--- a/dev/META6.json
+++ b/dev/META6.json
@@ -79,6 +79,7 @@
     "Agrammon::Preprocessor": "lib/Agrammon/Preprocessor.pm6",
     "Agrammon::UI::CommandLine": "lib/Agrammon/UI/CommandLine.pm6",
     "Agrammon::UI::Web": "lib/Agrammon/UI/Web.pm6",
+    "Agrammon::Validation": "lib/Agrammon/Validation.pm6",
     "Agrammon::Web::APIRoutes": "lib/Agrammon/Web/APIRoutes.pm6",
     "Agrammon::Web::APITokenManager": "lib/Agrammon/Web/APITokenManager.pm6",
     "Agrammon::Web::Routes": "lib/Agrammon/Web/Routes.pm6",

--- a/lib/Agrammon/Inputs.pm6
+++ b/lib/Agrammon/Inputs.pm6
@@ -84,6 +84,13 @@ class Agrammon::Inputs does Agrammon::Inputs::Storage {
         }
         @(%!multi-input-lists{$taxonomy} // [])
     }
+
+    #| Get a hash mapping single instance modules to a hash of their inputs,
+    #| and multi-instance modules to a list of pairs, where the key is the
+    #| instance ID and the value is the inputs for that instance.
+    method all-inputs() {
+        %(flat %!single-inputs, %!multi-input-lists.map({ .key => [.value.map({ .instance-id => .all-inputs })] }))
+    }
 }
 
 class X::Agrammon::Inputs::Distribution::AlreadyFlattened is Exception {

--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -91,6 +91,29 @@ class Agrammon::Model {
             }
         }
 
+        method extract-structure() {
+            my @top-level;
+            self!place-structure-into(@top-level);
+            @top-level
+        }
+
+        method !place-structure-into(@output, :$in-multi = False) {
+            if !$in-multi && $!module.is-multi {
+                my @children;
+                for @!dependencies -> $dep {
+                    $dep!place-structure-into(@children, :in-multi);
+                }
+                @children.push($!module.taxonomy);
+                @output.push(($!module.taxonomy => @children));
+            }
+            else {
+                @output.push($!module.taxonomy);
+                for @!dependencies -> $dep {
+                    $dep!place-structure-into(@output, :$in-multi);
+                }
+            }
+        }
+
         method run(:$input!, :%technical!) {
             my $outputs = Agrammon::Outputs.new();
             my $*AGRAMMON-LOG = $outputs.log-collector;
@@ -367,6 +390,15 @@ class Agrammon::Model {
 
     sub normalize($module-name) {
         $module-name.subst(/'::' <.ident> '::..'/, '', :g)
+    }
+
+    #| Obtains a description of the structure of the model, accounting for multiple
+    #| instance modules. The list returned contains single-instance modules as
+    #| string names of their taxonomies. A multi-instance module root is a pair,
+    #| where the key is the taxonomy name of the root of the multi-instance module
+    #| and the value is an array of the modules within that instance.
+    method extract-structure() {
+        $!entry-point.extract-structure
     }
 
     method run(Agrammon::Inputs :$input!, :%technical --> Agrammon::Outputs) {

--- a/lib/Agrammon/Model/Input.pm6
+++ b/lib/Agrammon/Model/Input.pm6
@@ -46,6 +46,8 @@ class Agrammon::Model::Input {
 
     method enum-ordered(--> Array) { @!enum-order }
 
+    method is-valid-enum-value($value) { %!enum-lookup{$value}:exists }
+
     method is-distribute(--> Bool) { $!distribute }
 
     method is-filter(--> Bool) { $!filter }

--- a/lib/Agrammon/Validation.pm6
+++ b/lib/Agrammon/Validation.pm6
@@ -1,0 +1,247 @@
+unit module Agrammon::Validation;
+use Agrammon::Inputs;
+use Agrammon::Model;
+
+#| The root of all validation problems found.
+role Problem {
+    #| The module where the problem was found.
+    has Str $.module is required;
+}
+
+#| An input value for a module that doesn't exist at all.
+class NoSuchModule does Problem {
+    #| The instance, if any.
+    has Str $.instance;
+
+    method message() {
+        "Input for module '$!module'" ~
+                ($!instance ?? " of instance $!instance" !! "") ~
+                ", but not such module exists in the model"
+    }
+}
+
+#| Multi-instance input for single-instance module.
+class MultiInputForSingleModule does Problem {
+    method message() {
+        "Input with instance for module '$!module', which is a single-instance module"
+    }
+}
+
+#| Single-instance input for multi-instance module.
+class SingleInputForMultiModule does Problem {
+    method message() {
+        "Input without instance for module '$!module', which is a multi-instance module"
+    }
+}
+
+#| The root of all problems concerning a particular input.
+role InputProblem does Problem {
+    #| The instance, if any.
+    has Str $.instance;
+
+    #| The input that the problem relates to.
+    has Str $.input is required;
+
+    method !prefix() {
+        "Input '$!input' in '$.module' " ~ ($!instance ?? "instance '$!instance' " !! "")
+    }
+}
+
+#| An input value for an input that does not exist.
+class NoSuchInput does InputProblem {
+    method message() {
+        self!prefix() ~ "does not exist in the model"
+    }
+}
+
+#| A missing required input.
+class MissingInput does InputProblem {
+    method message() {
+        self!prefix() ~ "is missing"
+    }
+}
+
+#| An input that is not of the correct type.
+class IncorrectType does InputProblem {
+    #| The expected type.
+    has Str $.expected-type is required;
+
+    #| The actual value.
+    has Any $.value is required;
+
+    method message() {
+        self!prefix() ~ " should be of type $!expected-type, but got value '$!value'"
+    }
+}
+
+#| An input for an enum type that has a value not valid for the enum.
+class InvalidEnumValue does InputProblem {
+    #| The valid enum values.
+    has @.valid is required;
+
+    #| The actual value.
+    has Any $.value is required;
+
+    method message() {
+        self!prefix() ~ " has value '$!value', which is not in the enum: " ~
+                @!valid.map({ "'$_'" }).join(",")
+    }
+}
+
+#| An input for a numeric type is out of range.
+class ValueOutOfRange does InputProblem {
+    #| The valid range.
+    has Range $.range is required;
+
+    #| The actual value.
+    has Any $.value is required;
+
+    method message() {
+        self!prefix() ~ " has value '$!value', which is not in the range $!range.raku()"
+    }
+}
+
+#| Validate the provided inputs against the model. Returns a list of validation
+#| errors; if there are no problems, the list will be empty.
+sub validation-errors(Agrammon::Model $model, Agrammon::Inputs $inputs --> List) is export {
+    # Obtain model structure and inputs to check. We will proceed by removing checked
+    # inputs from the hash, so those left over at the end are inputs for modules that
+    # do not exist.
+    my @model-structure := $model.extract-structure;
+    my %inputs-to-check = $inputs.all-inputs;
+
+    # We'll collect all problems into an array. First, go through the model structure.
+    my @problems;
+    for @model-structure {
+        when Str {
+            # Single instance module
+            my $input = %inputs-to-check{$_}:delete;
+            if $input ~~ Hash {
+                check-module-inputs($model.get-module($_), $input, @problems);
+            }
+            elsif $input ~~ List {
+                @problems.push: MultiInputForSingleModule.new(:module($_));
+            }
+        }
+        when Pair {
+            # Multi-instance module
+            my $entrypoint = .key;
+            my @modules = .value;
+            my $instances = %inputs-to-check{$entrypoint};
+            if $instances ~~ List {
+                # Go over the instances and check them.
+                for @$instances -> Pair $instance-data {
+                    my $instance = $instance-data.key;
+                    my %instance-input := $instance-data.value;
+                    for @modules -> $module {
+                        my %input := %instance-input{$module}:delete // {};
+                        check-module-inputs($model.get-module($module), %input, @problems, :$instance);
+                    }
+                    @problems.append: %instance-input.keys.map: { NoSuchModule.new(:$^module, :$instance) }
+                }
+                %inputs-to-check{$entrypoint}:delete;
+            }
+            else {
+                # Report errors for all single-instance input data for multi modules in
+                # this part of the graph.
+                for @modules -> $module {
+                    if %inputs-to-check{$module}:delete ~~ Map {
+                        @problems.push: SingleInputForMultiModule.new(:$module);
+                    }
+                }
+            }
+        }
+    }
+
+    # Report bogus modules.
+    @problems.append: %inputs-to-check.keys.map: { NoSuchModule.new(:$^module) }
+
+    return @problems;
+}
+
+sub check-module-inputs(Agrammon::Model::Module $module, %inputs is copy, @problems, Str :$instance --> Nil) {
+    # Check the inputs we have.
+    for $module.input -> $input {
+        with %inputs{$input.name}:delete -> $value {
+            given $input.type {
+                when 'integer' {
+                    if $value ~~ Int {
+                        check-range($module, $input, $instance, $value, @problems);
+                    }
+                    else {
+                        report-invalid-type($module, $input, $instance, $value, @problems);
+                    }
+                }
+                when 'float' {
+                    if $value ~~ Real {
+                        check-range($module, $input, $instance, $value, @problems);
+                    }
+                    else {
+                        report-invalid-type($module, $input, $instance, $value, @problems);
+                    }
+                }
+                when 'percent' {
+                    if $value ~~ Real && 0 <= $value <= 100 {
+                        check-range($module, $input, $instance, $value, @problems);
+                    }
+                    else {
+                        report-invalid-type($module, $input, $instance, $value, @problems);
+                    }
+                }
+                when 'enum' {
+                    unless $input.is-valid-enum-value($value) {
+                        @problems.push: InvalidEnumValue.new: :module($module.taxonomy), :$instance,
+                                :input($input.name), :valid($input.enum-ordered.map(*.key)), :$value;
+                    }
+                }
+                when 'text' {
+                    # Nothing to check
+                }
+                default {
+                    warn "Unknown input type in validation: $_";
+                }
+            }
+        }
+        else {
+            without $input.default-calc {
+                @problems.push: MissingInput.new(:module($module.taxonomy), :$instance, :input($input.name));
+            }
+        }
+    }
+
+    # Report unexpected inputs.
+    @problems.append: %inputs.keys.map: {
+        NoSuchInput.new(:module($module.taxonomy), :$instance, :$^input)
+    }
+}
+
+sub report-invalid-type(Agrammon::Model::Module $module, Agrammon::Model::Input $input,
+                        Str $instance, Any $value, @problems --> Nil) {
+    @problems.push: IncorrectType.new: :module($module.taxonomy), :$instance,
+            :input($input.name), :expected-type($input.type), :$value;
+}
+
+my regex number { '-'? \d+ ['.' \d+ ]? }
+
+sub check-range(Agrammon::Model::Module $module, Agrammon::Model::Input $input,
+                Str $instance, Real $value, @problems --> Nil) {
+    my $validator = $input.validator;
+    return unless $validator;
+    my $range = do given $validator {
+        when /:s ^ 'between' '(' <from=&number> ',' <to=&number> ')' ';'? $/ {
+            +$<from> .. +$<to>
+        }
+        when /:s ^ 'ge' '(' <number> ')' ';'? $/ { +$<number> .. *  }
+        when /:s ^ 'gt' '(' <number> ')' ';'? $/ { +$<number> ^.. *  }
+        when /:s ^ 'le' '(' <number> ')' ';'? $/ { * .. +$<number> }
+        when /:s ^ 'lt' '(' <number> ')' ';'? $/ { * ..^ +$<number> }
+        default {
+            warn "Unknown validator '$_'";
+            return;
+        }
+    }
+    if $value !~~ $range {
+        @problems.push: ValueOutOfRange.new: :module($module.taxonomy), :$instance,
+            :input($input.name), :$range, :$value;
+    }
+}

--- a/lib/Agrammon/Validation.pm6
+++ b/lib/Agrammon/Validation.pm6
@@ -16,7 +16,7 @@ class NoSuchModule does Problem {
     method message() {
         "Input for module '$!module'" ~
                 ($!instance ?? " of instance $!instance" !! "") ~
-                ", but not such module exists in the model"
+                ", but no such module exists in the model"
     }
 }
 

--- a/t/test-data/Models/validation/Test.nhd
+++ b/t/test-data/Models/validation/Test.nhd
@@ -1,0 +1,125 @@
+*** general ***
+
+author   = Jonathan Worthington
+date     = 2021-06-09
+taxonomy = Test
+
++short
+
+  For testing validation
+
++description
+
+  Top-level module
+
+*** input ***
+
++an_int
+  type = integer
+  ++labels
+    en = An int
+  ++units
+    en = -
+
++an_optional_int
+  type = integer
+  default_calc = 0
+  ++labels
+    en = An int
+  ++units
+    en = -
+
++a_float
+  type = float
+  ++labels
+    en = A float
+  ++units
+    en = -
+
++a_percentage
+  type = percent
+  ++labels
+    en = A percentage
+  ++units
+    en = -
+
++a_string
+  type = text
+  ++labels
+    en = A text string
+  ++units
+    en = -
+
++an_enum
+  type = enum
+  default_calc = third
+  ++enum
+    +++first
+       en = The worst
+    +++second
+       en = The best
+    +++third
+       en = The turd
+
++with_between
+  type = integer
+  validator = between(4000,15000);
+  default_calc = 5000
+  ++labels
+    en = With between
+  ++units
+    en = -
+
++with_ge
+  type = integer
+  validator = ge(0);
+  default_calc = 5
+  ++labels
+    en = With ge
+  ++units
+    en = -
+
++with_gt
+  type = float
+  validator = gt(5.5);
+  default_calc = 6.5
+  ++labels
+    en = With gt
+  ++units
+    en = -
+
++with_le
+  type = integer
+  validator = le(100);
+  default_calc = 6
+  ++labels
+    en = With le
+  ++units
+    en = -
+
++with_lt
+  type = float
+  validator = lt(5.5);
+  default_calc = 2.5
+  ++labels
+    en = With lt
+  ++units
+    en = -
+
+*** external ***
+
++Test::SubModule
+  aggregate=SUM
+
+*** output ***
+
++result
+  print = 7
+  ++units
+    en = monkeys/hour
+    de = affen/Stunde
+  ++formula
+    Sum(a_natural, Test::SubModule) *
+    (In(an_int) * In(a_float) * In(a_percentage))
+  ++description
+    Final result

--- a/t/test-data/Models/validation/Test/SubModule.nhd
+++ b/t/test-data/Models/validation/Test/SubModule.nhd
@@ -1,0 +1,39 @@
+*** general ***
+
+author   = Jonathan Worthington
+date     = 2021-06-09
+taxonomy = Test::SubModule
+instances = multi
+
++short
+
+  For testing validation
+
++description
+
+  Multi instance test sub module.
+
+*** input ***
+
++a_natural
+  type = integer
+  validator = gt(0)
+  ++labels
+    en = Natural
+  ++units
+    en = -
+
+*** external ***
+
++SubModule::SubTest
+
+*** output ***
+
++a_natural
+  print = 7
+  ++units
+    en = monkeys/hour
+  ++formula
+    In(a_natural)
+  ++description
+    Final result

--- a/t/test-data/Models/validation/Test/SubModule/SubTest.nhd
+++ b/t/test-data/Models/validation/Test/SubModule/SubTest.nhd
@@ -1,0 +1,41 @@
+*** general ***
+
+author   = Jonathan Worthington
+date     = 2021-06-09
+taxonomy = Test::SubModule::SubTest
+
++short
+
+  For testing validation
+
++description
+
+  2nd level multi instance test sub module.
+
+*** input ***
+
++an_enum
+  type = enum
+  ++labels
+    en = An enum
+  ++units
+    en = -
+  ++enum
+    +++ipa
+       en = Indian Pale Ale
+    +++neipa
+       en = North East Indian Pale Ale
+    +++apa
+       en = American Pale Ale
+
+
+*** output ***
+
++an_enum
+  print = 7
+  ++units
+    en = monkeys
+  ++formula
+    In(an_enum)
+  ++description
+    Blah

--- a/t/test-data/validation.csv
+++ b/t/test-data/validation.csv
@@ -1,0 +1,66 @@
+ValidationTest;1;Test;an_int;42
+ValidationTest;1;Test;an_optional_int;2
+ValidationTest;1;Test;a_float;4.1
+ValidationTest;1;Test;a_percentage;100
+ValidationTest;1;Test;a_string;hovinko
+ValidationTest;1;Test;an_enum;second
+ValidationTest;1;Test;with_between;10000
+ValidationTest;1;Test;with_ge;0
+ValidationTest;1;Test;with_gt;12.5
+ValidationTest;1;Test;with_le;2
+ValidationTest;1;Test;with_lt;2.5
+ValidationTest;2;Test;an_int;42
+ValidationTest;2;Test;a_percentage;0
+ValidationTest;3;Test;an_int;42
+ValidationTest;3;Test;a_float;4.1
+ValidationTest;3;Test;a_percentage;100
+ValidationTest;3;Test;a_string;hovinko
+ValidationTest;3;Test;a_bogus_input;mrkev
+ValidationTest;3;Wat;bogosity;blbost
+ValidationTest;4;Test;an_int;4.1
+ValidationTest;4;Test;a_float;nope
+ValidationTest;4;Test;a_percentage;102
+ValidationTest;4;Test;a_string;all strings are ok
+ValidationTest;5;Test;an_int;42
+ValidationTest;5;Test;a_float;4
+ValidationTest;5;Test;a_percentage;9.99
+ValidationTest;5;Test;a_string;hovinko
+ValidationTest;5;Test;an_enum;sixth
+ValidationTest;6;Test;an_int;42
+ValidationTest;6;Test;a_float;4.1
+ValidationTest;6;Test;a_percentage;100
+ValidationTest;6;Test;a_string;hovinko
+ValidationTest;6;Test;with_between;16000
+ValidationTest;6;Test;with_ge;-1
+ValidationTest;6;Test;with_gt;5.5
+ValidationTest;6;Test;with_le;101
+ValidationTest;6;Test;with_lt;5.5
+ValidationTest;7;Test[Instance 1];an_int;42
+ValidationTest;7;Test[Instance 1];a_float;4.1
+ValidationTest;7;Test[Instance 1];a_percentage;100
+ValidationTest;7;Test[Instance 1];a_string;hovinko
+ValidationTest;8;Test;an_int;42
+ValidationTest;8;Test;a_float;4.1
+ValidationTest;8;Test;a_percentage;100
+ValidationTest;8;Test;a_string;hovinko
+ValidationTest;8;Test::SubModule::SubTest;an_enum;ipa
+ValidationTest;8;Test::SubModule;a_natural;1
+ValidationTest;9;Test;an_int;42
+ValidationTest;9;Test;a_float;4.1
+ValidationTest;9;Test;a_percentage;100
+ValidationTest;9;Test;a_string;hovinko
+ValidationTest;9;Test::SubModule[Instance 1]::SubTest;an_enum;ipa
+ValidationTest;9;Test::SubModule[Instance 1];a_natural;1
+ValidationTest;9;Test::SubModule[Instance 2]::SubTest;an_enum;lager
+ValidationTest;9;Test::SubModule[Instance 2];a_natural;42
+ValidationTest;9;Test::SubModule[Instance 3]::SubTest;an_enum;neipa
+ValidationTest;9;Test::SubModule[Instance 3];a_natural;0
+ValidationTest;9;Test::SubModule[Instance 4]::SubTest;an_enum;neipa
+ValidationTest;9;Test::SubModule[Instance 4];a_natural;string
+ValidationTest;9;Test::SubModule[Instance 5];a_natural;9
+ValidationTest;9;Test::SubModule[Instance 6]::SubTest;an_enum;ipa
+ValidationTest;9;Test::SubModule[Instance 6];a_natural;1
+ValidationTest;9;Test::SubModule[Instance 6];a_non_existing;99
+ValidationTest;9;Test::SubModule[Instance 7]::SubTest;an_enum;ipa
+ValidationTest;9;Test::SubModule[Instance 7];a_natural;1
+ValidationTest;9;Test::SubModule[Instance 7]::Who;am_i;spartacus

--- a/t/validation.t
+++ b/t/validation.t
@@ -1,0 +1,190 @@
+use Agrammon::DataSource::CSV;
+use Agrammon::Validation;
+use Test;
+
+my $path = $*PROGRAM.parent.add('test-data/Models/validation');
+my $model = Agrammon::Model.new(:$path);
+lives-ok { $model.load('Test') },
+        'Loaded model to use for testing validation';
+
+my $filename = $*PROGRAM.parent.add('test-data/validation.csv');
+my $fh = open $filename, :r;
+my $ds = Agrammon::DataSource::CSV.new;
+my @datasets = $ds.read($fh);
+$fh.close;
+is @datasets.elems, 9, 'Loaded datasets to validate';
+
+subtest 'Single instance inputs with no problems' => {
+    given @datasets[0] -> $dataset {
+        my @validation-errors;
+        lives-ok { @validation-errors = validation-errors($model, $dataset) },
+                'Performed validation of the inputs against the model';
+        is @validation-errors.elems, 0, 'There are no validation errors';
+    }
+}
+
+subtest 'Missing inputs (single instance)' => {
+    given @datasets[1] -> $dataset {
+        my @validation-errors;
+        lives-ok { @validation-errors = validation-errors($model, $dataset) },
+                'Performed validation of the inputs against the model';
+        is @validation-errors.elems, 2, 'Got two validation errors as expected';
+        ok all(@validation-errors) ~~ Agrammon::Validation::MissingInput,
+            'Got missing input errors as expected';
+        ok all(@validation-errors).module eq 'Test', 'All have correct module';
+        is @validation-errors.map(*.input).sort, <a_float a_string>,
+            'Correct inputs are reported missing';
+    }
+}
+
+subtest 'Inputs with no matching module or input (single instance)' => {
+    given @datasets[2] -> $dataset {
+        my @validation-errors;
+        lives-ok { @validation-errors = validation-errors($model, $dataset) },
+                'Performed validation of the inputs against the model';
+        is @validation-errors.elems, 2, 'Got two validation errors as expected';
+        given @validation-errors.first(Agrammon::Validation::NoSuchModule) {
+            isa-ok $_, Agrammon::Validation::NoSuchModule, 'Got no such module error';
+            is .module, 'Wat', 'Correct module name reported';
+        }
+        given @validation-errors.first(Agrammon::Validation::NoSuchInput) {
+            isa-ok $_, Agrammon::Validation::NoSuchInput, 'Got no such input error';
+            is .module, 'Test', 'Correct module name reported';
+            is .input, 'a_bogus_input', 'Correct input name reported';
+        }
+    }
+}
+
+subtest 'Inputs with wrong type (single instance)' => {
+    given @datasets[3] -> $dataset {
+        my @validation-errors;
+        lives-ok { @validation-errors = validation-errors($model, $dataset) },
+                'Performed validation of the inputs against the model';
+        is @validation-errors.elems, 3, 'Got 3 validation errors as expected';
+        ok all(@validation-errors) ~~ Agrammon::Validation::IncorrectType,
+                'All errors are about type';
+        ok all(@validation-errors).module eq 'Test',
+                'Errors are reported against the correct module';
+        @validation-errors .= sort(*.input);
+        is @validation-errors[0].input, 'a_float', 'Correct first input in validation error';
+        is @validation-errors[0].expected-type, 'float', 'Correct first expected type in validation error';
+        is @validation-errors[1].input, 'a_percentage', 'Correct second input in validation error';
+        is @validation-errors[1].expected-type, 'percent', 'Correct second expected type in validation error';
+        is @validation-errors[2].input, 'an_int', 'Correct third input in validation error';
+        is @validation-errors[2].expected-type, 'integer', 'Correct third expected type in validation error';
+    }
+}
+
+subtest 'Invalid enum value (single instance)' => {
+    given @datasets[4] -> $dataset {
+        my @validation-errors;
+        lives-ok { @validation-errors = validation-errors($model, $dataset) },
+                'Performed validation of the inputs against the model';
+        is @validation-errors.elems, 1, 'Got one validation error as expected';
+        given @validation-errors[0] {
+            isa-ok $_, Agrammon::Validation::InvalidEnumValue,
+                'Got invalid enum value error as expected';
+            is .module, 'Test', 'Have correct module';
+            is .input, 'an_enum', 'Have correct input';
+            is-deeply .valid, [<first second third>], 'Have correct valid values';
+        }
+    }
+}
+
+subtest 'Inputs with values out of range (single instance)' => {
+    given @datasets[5] -> $dataset {
+        my @validation-errors;
+        lives-ok { @validation-errors = validation-errors($model, $dataset) },
+            'Performed validation of the inputs against the model';
+        is @validation-errors.elems, 5, 'Got two validation errors as expected';
+        ok all(@validation-errors) ~~ Agrammon::Validation::ValueOutOfRange,
+            'All errors were value out of range errors';
+        is all(@validation-errors).module, 'Test', 'Correct module in call errors';
+        is-deeply @validation-errors.sort(*.input).map({ .input => .range }).hash,
+            {
+                with_between => 4000..15000,
+                with_ge => 0..*,
+                with_gt => 5.5^..*,
+                with_le => *..100,
+                with_lt => *..^5.5
+            },
+            'Correct validation ranges';
+    }
+}
+
+subtest 'Multi-instance data for single-instance module' => {
+    given @datasets[6] -> $dataset {
+        my @validation-errors;
+        lives-ok { @validation-errors = validation-errors($model, $dataset) },
+                'Performed validation of the inputs against the model';
+        is @validation-errors.elems, 1, 'Got one validation error as expected';
+        given @validation-errors[0] {
+            isa-ok $_, Agrammon::Validation::MultiInputForSingleModule,
+                    'Got multiple input for single instance module error as expected';
+            is .module, 'Test', 'Have correct module';
+        }
+    }
+}
+
+subtest 'Single-instance data for multi-instance module' => {
+    given @datasets[7] -> $dataset {
+        my @validation-errors;
+        lives-ok { @validation-errors = validation-errors($model, $dataset) },
+                'Performed validation of the inputs against the model';
+        is @validation-errors.elems, 2, 'Got two validation error as expected';
+        ok all(@validation-errors) ~~ Agrammon::Validation::SingleInputForMultiModule,
+                'All errors complain about single instance input for multi instance modules';
+        is @validation-errors.map(*.module).sort, <Test::SubModule Test::SubModule::SubTest>,
+            'Correct modules are complained about';
+    }
+}
+
+subtest 'Problems in multiple-instance modules' => {
+    given @datasets[8] -> $dataset {
+        my @validation-errors;
+        lives-ok { @validation-errors = validation-errors($model, $dataset) },
+                'Performed validation of the inputs against the model';
+        is @validation-errors.elems, 6, 'Got six validation error as expected';
+        dd @validation-errors;
+        @validation-errors .= sort(*.instance);
+        given @validation-errors[0] {
+            isa-ok $_, Agrammon::Validation::InvalidEnumValue,
+                'Got an invalid enum error';
+            is .module, 'Test::SubModule::SubTest', 'It is on the correct module';
+            is .instance, 'Instance 2', 'It is on the correct instance';
+        }
+        given @validation-errors[1] {
+            isa-ok $_, Agrammon::Validation::ValueOutOfRange,
+                    'Got a value out of range error';
+            is .module, 'Test::SubModule', 'It is on the correct module';
+            is .instance, 'Instance 3', 'It is on the correct instance';
+        }
+        given @validation-errors[2] {
+            isa-ok $_, Agrammon::Validation::IncorrectType,
+                    'Got an incorrect type error';
+            is .module, 'Test::SubModule', 'It is on the correct module';
+            is .instance, 'Instance 4', 'It is on the correct instance';
+        }
+        given @validation-errors[3] {
+            isa-ok $_, Agrammon::Validation::MissingInput,
+                    'Got an missing input error';
+            is .module, 'Test::SubModule::SubTest', 'It is on the correct module';
+            is .instance, 'Instance 5', 'It is on the correct instance';
+            is .input, 'an_enum', 'It complains about the correct missing input';
+        }
+        given @validation-errors[4] {
+            isa-ok $_, Agrammon::Validation::NoSuchInput,
+                    'Got a no such input error';
+            is .module, 'Test::SubModule', 'It is on the correct module';
+            is .instance, 'Instance 6', 'It is on the correct instance';
+            is .input, 'a_non_existing', 'It identifies the correct input';
+        }
+        given @validation-errors[5] {
+            isa-ok $_, Agrammon::Validation::NoSuchModule,
+                    'Got a no such module error';
+            is .module, 'Test::SubModule::Who', 'It is on the correct module';
+        }
+    }
+}
+
+done-testing;


### PR DESCRIPTION
This catches a wide range of problems, including:

* Inputs for modules that don't exist
* Single-instance inputs for multi-instance modules and vice versa
* Missing inputs that don't have a default_calc
* Inputs whose value does not match the type
* Inputs for enum types where the value does not fall within the enum
* Inputs with range constraints (`between`, `ge`) that are not met by
  the value

For multi-instance modules, the instance at fault is also reported in
the error. A list of error objects is produced. This is not yet in any
way integrated with the overall workflow. Since we weren't validating
these things before, it's possible that starting to do so will turn up
genuine mistakes in input data. It's also possible more realistic data
will turn up problems in this validator, although hopefully the decent
level of test coverage here will mean we don't see too much of that.