### PR TITLE
Add input validation to command line and web

### DIFF
--- a/lib/Agrammon/ResultCollector.pm6
+++ b/lib/Agrammon/ResultCollector.pm6
@@ -5,8 +5,8 @@ monitor Agrammon::ResultCollector {
     has %.results;
     has %.validation-errors;
 
-    method add-validation-errors($simulation-name, $dataset-id, $errors --> Nil) {
-        %!validation-errors{$simulation-name}{$dataset-id} = $errors;
+    method add-validation-errors($simulation-name, $dataset-id, @errors --> Nil) {
+        %!validation-errors{$simulation-name}{$dataset-id} = @errors;
     }
     method add-result($simulation-name, $dataset-id, $result --> Nil) {
         %!results{$simulation-name}{$dataset-id} = $result;

--- a/lib/Agrammon/ResultCollector.pm6
+++ b/lib/Agrammon/ResultCollector.pm6
@@ -3,7 +3,11 @@ use OO::Monitors;
 
 monitor Agrammon::ResultCollector {
     has %.results;
+    has %.validation-errors;
 
+    method add-validation-errors($simulation-name, $dataset-id, $errors --> Nil) {
+        %!validation-errors{$simulation-name}{$dataset-id} = $errors;
+    }
     method add-result($simulation-name, $dataset-id, $result --> Nil) {
         %!results{$simulation-name}{$dataset-id} = $result;
     }

--- a/lib/Agrammon/UI/CommandLine.pm6
+++ b/lib/Agrammon/UI/CommandLine.pm6
@@ -251,8 +251,7 @@ sub run (IO::Path $path, IO::Path $input-path, $technical-file, $variants, $form
     my class X::EarlyFinish is Exception {}
     race for $ds.read($fh).race(:$batch, :$degree) -> $dataset {
         my $my-n = ++⚛$n;
-        my @validation-errors = validation-errors($model, $dataset);
-        if @validation-errors.elems {
+        if validation-errors($model, $dataset) -> @validation-errors {
             $rc.add-validation-errors($dataset.simulation-name, $dataset.dataset-id, @validation-errors);
         }
         else {
@@ -319,8 +318,7 @@ sub validate (IO::Path $path, IO::Path $input-path, $variants, $batch, $degree, 
     my class X::EarlyFinish is Exception {}
     race for $ds.read($fh).race(:$batch, :$degree) -> $dataset {
         my $my-n = ++⚛$n;
-        my @validation-errors = validation-errors($model, $dataset);
-        if @validation-errors.elems {
+        if validation-errors($model, $dataset) -> @validation-errors {
             $rc.add-validation-errors($dataset.simulation-name, $dataset.dataset-id, @validation-errors);
         }
 

--- a/lib/Agrammon/UI/CommandLine.pm6
+++ b/lib/Agrammon/UI/CommandLine.pm6
@@ -54,8 +54,8 @@ multi sub MAIN('run', ExistingFile $filename, ExistingFile $input, Str $technica
     my $data = run $filename.IO, $input.IO, $technical-file, $variants, $format, $language, $prints,
             ($include-filters or $include-all-filters),
             $batch, $degree, $max-runs, :all-filters($include-all-filters);
-    my %results = $data.results;
-    my %validation-errors = $data.validation-errors;
+    my %results := $data.results;
+    my %validation-errors := $data.validation-errors;
 
     my $output;
     if $format eq 'json' {
@@ -72,6 +72,7 @@ multi sub MAIN('run', ExistingFile $filename, ExistingFile $input, Str $technica
                 for %sim-errors.keys.sort -> $dataset {
                     @output.push("#   Dataset $dataset");
                     for @(%sim-errors{$dataset}) -> $error {
+                        # TODO: add translations
                         @output.push('#   ' ~ $error.message);
                     }
                 }
@@ -93,7 +94,7 @@ multi sub MAIN('run', ExistingFile $filename, ExistingFile $input, Str $technica
 }
 
 #| Validate inputs
-multi sub MAIN('validate', ExistingFile $filename, ExistingFile $input, Str :$variants = 'Base',
+multi sub MAIN('validate', ExistingFile $filename, ExistingFile $input, SupportedLanguage :$language = 'de', Str :$variants = 'Base',
                Int :$batch=1, Int :$degree=4, Int :$max-runs
               ) is export {
     my %validation-errors = validate $filename.IO, $input.IO, $variants,
@@ -106,6 +107,7 @@ multi sub MAIN('validate', ExistingFile $filename, ExistingFile $input, Str :$va
             @output.push("### Simulation $simulation");
             for %sim-errors.keys.sort -> $dataset {
                 @output.push("#   Dataset $dataset");
+                # TODO: add translations
                 @output.push(%sim-errors{$dataset}.message);
             }
         }
@@ -252,7 +254,6 @@ sub run (IO::Path $path, IO::Path $input-path, $technical-file, $variants, $form
         my @validation-errors = validation-errors($model, $dataset);
         if @validation-errors.elems {
             $rc.add-validation-errors($dataset.simulation-name, $dataset.dataset-id, @validation-errors);
-#            dd @validation-errors;
         }
         else {
             my $outputs = timed "$my-n: Run $filename", {

--- a/lib/Agrammon/Web/Service.pm6
+++ b/lib/Agrammon/Web/Service.pm6
@@ -203,7 +203,7 @@ class Agrammon::Web::Service {
         my $validation-errors = self!get-outputs($user, $dataset-name)<validation-errors>;
         warn '**** Got ' ~  $validation-errors.elems ~ ' input validation errors';
         # TODO: get with-filters from frontend
-        # TODO: deal with validation errors in front end
+        # TODO: deal with validation errors in frontend; needs translations
         my %gui-output = output-for-gui($!model, $results, :include-filters);
         note '**** with-filters for get-output-variables() not yet completely implemented';
         return %gui-output;

--- a/lib/Agrammon/Web/Service.pm6
+++ b/lib/Agrammon/Web/Service.pm6
@@ -14,8 +14,9 @@ use Agrammon::OutputFormatter::PDF;
 use Agrammon::OutputFormatter::Text;
 use Agrammon::Performance;
 use Agrammon::Timestamp;
-use Agrammon::Web::SessionUser;
 use Agrammon::UI::Web;
+use Agrammon::Validation;
+use Agrammon::Web::SessionUser;
 
 class Agrammon::Web::Service {
     has Agrammon::Config $.cfg;
@@ -181,20 +182,29 @@ class Agrammon::Web::Service {
     }
 
     method !get-outputs(Agrammon::Web::SessionUser $user, Str $dataset-name) {
-        return $!outputs-cache.get-or-calculate: $user.username, $dataset-name, -> {
+        my $input = self!get-inputs($user, $dataset-name);
+        my @validation-errors = validation-errors($!model, $input);
+        my $results = $!outputs-cache.get-or-calculate: $user.username, $dataset-name, -> {
             timed "$dataset-name", {
                 $!model.run:
-                        :input(self!get-inputs($user, $dataset-name)),
+                        :$input,
                         technical => %!technical-parameters;
             }
-        }
+        };
+
+         return {
+             :$results,
+             :@validation-errors,
+        };
     }
 
     method get-output-variables(Agrammon::Web::SessionUser $user, Str $dataset-name) {
-        my $outputs = self!get-outputs($user, $dataset-name);
-
+        my $results = self!get-outputs($user, $dataset-name)<results>;
+        my $validation-errors = self!get-outputs($user, $dataset-name)<validation-errors>;
+        warn '**** Got ' ~  $validation-errors.elems ~ ' input validation errors';
         # TODO: get with-filters from frontend
-        my %gui-output = output-for-gui($!model, $outputs, :include-filters);
+        # TODO: deal with validation errors in front end
+        my %gui-output = output-for-gui($!model, $results, :include-filters);
         note '**** with-filters for get-output-variables() not yet completely implemented';
         return %gui-output;
     }
@@ -205,7 +215,7 @@ class Agrammon::Web::Service {
         my $report-selected = %params<reportSelected>.Int;
 
         my $inputs  = self!get-inputs($user, $dataset-name);
-        my $outputs = self!get-outputs($user, $dataset-name);
+        my $outputs = self!get-outputs($user, $dataset-name)<results>;
         my $reports = self.get-input-variables<reports>;
 
         my $type = $reports[$report-selected]<type> // '';
@@ -246,7 +256,7 @@ class Agrammon::Web::Service {
         }
 
         my $inputs  = self!get-inputs($user, $dataset-name);
-        my $outputs = self!get-outputs($user, $dataset-name);
+        my $outputs = self!get-outputs($user, $dataset-name)<results>;
         my $reports = self.get-input-variables<reports>;
 
         my $type = $reports[$report-selected]<type> // '';


### PR DESCRIPTION
- Add `validate` command to command line interface
- Integrate input validation into `run` and `web` command

The web integration is currently only writing a warning about input validation as we haven't decided yet how to deal with invalid inputs in the GUI.
Handling of validation errors in the `run` command for multiple datasets in the CSV file also needs to be discussed with the customer (abort whole run or report correct results and validation errors separately). For single datasets in the CSV file this works sensibly.