### PR TITLE
Fix accept header in REST api

### DIFF
--- a/dev/META6.json
+++ b/dev/META6.json
@@ -12,7 +12,7 @@
     "Cro::Core",
     "Cro::HTTP",
     "Cro::HTTP::Session::Pg",
-    "Cro::OpenAPI::RoutesFromDefinition<1.0.2+>",
+    "Cro::OpenAPI::RoutesFromDefinition:ver<1.0.2+>",
     "Cro::WebApp::Template",
     "Cro::APIToken",
     "Cro::APIToken::Store::Pg",

--- a/dev/META6.json
+++ b/dev/META6.json
@@ -12,7 +12,7 @@
     "Cro::Core",
     "Cro::HTTP",
     "Cro::HTTP::Session::Pg",
-    "Cro::OpenAPI::RoutesFromDefinition",
+    "Cro::OpenAPI::RoutesFromDefinition<1.0.2+>",
     "Cro::WebApp::Template",
     "Cro::APIToken",
     "Cro::APIToken::Store::Pg",

--- a/lib/Agrammon/Web/APIRoutes.pm6
+++ b/lib/Agrammon/Web/APIRoutes.pm6
@@ -56,10 +56,10 @@ sub rest-api-routes (Str $schema, Agrammon::Web::Service $ws) is export {
             content 'text/plain', $ws.get-technical($technical);
         }
 
-        operation 'runSimulation', -> APIUser $user {
+        operation 'runSimulation', -> APIUser $user, :$accept is header = 'text/plain' {
             request-body 'multipart/form-data' => -> (
                 :$simulation!,  :$dataset!, :$inputs!, :$technical='',
-                :$model = 'version6', :$variants = 'Base', :$language = 'de', :$accept is header = 'text/plain',
+                :$model = 'version6', :$variants = 'Base', :$language = 'de',
                 :$print-only = '', :$include-filters = 'false', :$all-filters = 'false'
             ) {
                 my $type = $inputs.content-type;


### PR DESCRIPTION
`:$accept` is a request header and not part of the request body