### PR TITLE
Simplify openapi and add tests

### DIFF
--- a/dev/META6.json
+++ b/dev/META6.json
@@ -12,7 +12,7 @@
     "Cro::Core",
     "Cro::HTTP",
     "Cro::HTTP::Session::Pg",
-    "Cro::OpenAPI::RoutesFromDefinition:ver<1.0.2+>",
+    "Cro::OpenAPI::RoutesFromDefinition:ver<1.0.4+>",
     "Cro::WebApp::Template",
     "Cro::APIToken",
     "Cro::APIToken::Store::Pg",

--- a/share/agrammon-rest.openapi
+++ b/share/agrammon-rest.openapi
@@ -31,7 +31,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/Unauthorized"
+                                $ref: "#/components/schemas/Error"
     /model/latex:
         get:
             summary: Get LaTeX model documentation
@@ -55,12 +55,18 @@ paths:
                         text/plain:
                             schema:
                                 type: string
+                '400':
+                    description: Invalid input
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
                 '401':
                     description: Not authorized.
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/Unauthorized"
+                                $ref: "#/components/schemas/Error"
     /inputTemplate:
         get:
             summary: Get model input template CSV file
@@ -80,12 +86,18 @@ paths:
                         text/csv:
                             schema:
                                 type: string
+                '400':
+                    description: Invalid request.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
                 '401':
                     description: Not authorized.
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/Unauthorized"
+                                $ref: "#/components/schemas/Error"
     /run:
         post:
             summary: Run simulation
@@ -112,12 +124,18 @@ paths:
                         text/plain:
                             schema:
                                 description: text formatted
+                '400':
+                    description: Invalid request.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
                 '401':
                     description: Not authorized.
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/Unauthorized"
+                                $ref: "#/components/schemas/Error"
 components:
     schemas:
         Run:
@@ -166,19 +184,7 @@ components:
                     enum:
                         - 'true'
                         - 'false'
-        Unauthorized:
-            required:
-                - error
-            properties:
-                error:
-                    type: string
         Error:
-            required:
-                - error
-            properties:
-                error:
-                    type: string
-        Unknown:
             required:
                 - error
             properties:

--- a/t/apiroutes.t
+++ b/t/apiroutes.t
@@ -190,7 +190,7 @@ done-testing;
 
 =begin pod
 
-=COPYRIGHT Copyright (c) 2020 by OETIKER+PARTNER AG. All rights reserved.
+=COPYRIGHT Copyright (c) 2021 by OETIKER+PARTNER AG. All rights reserved.
 
 =AUTHOR S<Fritz Zaucker E<lt>fritz.zaucker@oetiker.chE<gt>>
 


### PR DESCRIPTION
Add tests for valid and invalid optional parameters.
While the test for the unknown parameter does fail validation as expected, the invalid values for `language`, `model`, and `variants` (defined as enums) do not fail validation and return 200.