### PR TITLE
Fix flattening and migrate flattened regional input data

### DIFF
--- a/frontend/source/class/agrammon/module/input/NavBar.js
+++ b/frontend/source/class/agrammon/module/input/NavBar.js
@@ -601,14 +601,6 @@ qx.Class.define('agrammon.module.input.NavBar', {
                 default:
                     if ( rec.type.match(/enum/) ) { // combobox
                         var olen = rec.options.length;
-// TODO: remove unless needed
-//                        for (var o=0; o<olen; o++) {
-//                            if (rec.options[o] != undefined && rec.options[o][0] == 'ignore') {
-//                                rec.options.splice(o,1);
-//                                rec.optionsLang.splice(o,1);
-//                                this.debug('Removed ignore options:', rec.options[o]);
-//                            }
-//                        }
                         metaData.options     = rec.options;
                         metaData.optionsLang = rec.optionsLang;
                     }
@@ -634,7 +626,8 @@ qx.Class.define('agrammon.module.input.NavBar', {
                     units:        rec.units,
                     helpFunction: helpFunction,
                     show:         rec.show,
-                    order:        rec.order
+                    order:        rec.order,
+                    filter:       rec.filter
                 });
                 navFolder.addData(variable);
 

--- a/frontend/source/class/agrammon/module/input/NavFolder.js
+++ b/frontend/source/class/agrammon/module/input/NavFolder.js
@@ -408,7 +408,7 @@ qx.Class.define('agrammon.module.input.NavFolder', {
                     if (value == undefined) {
                         value = this.__propData[i].getDefaultValue();
                     }
-                    if (value == 'branched' || value == 'branchedX') {
+                    if (value == 'branched') {
                         metaData['branches'] = branch_values;
                         this.__propData[i].setMetaParameter('branches', branch_values);
                     }
@@ -422,7 +422,6 @@ qx.Class.define('agrammon.module.input.NavFolder', {
                         value = '' + value;
                         value = value.replace(/\s+/g, '');
                         value = value.replace(/\'/g,'');
-
                         // TODO: remove if statement
                         if (value != '***Select***' && value != 'ignore') {
                             options = new Array();
@@ -518,7 +517,10 @@ qx.Class.define('agrammon.module.input.NavFolder', {
                 var comment = data.getComment();
                 var meta = data.getMetaData();
                 this.__propData.push(data);
-
+                // prevent default value (*** Select ***) on instance creation
+                if (name.match(/_flattened/) && value === null) {
+                    value = '';
+                }
                 if (storeAll) {
                     if (handleIgnore && name.match(/::ignore/)) { // FIX ME
                         this.setData(name, 'ignore', null, noCheck, null);

--- a/frontend/source/class/agrammon/module/input/Variable.js
+++ b/frontend/source/class/agrammon/module/input/Variable.js
@@ -43,6 +43,7 @@ qx.Class.define('agrammon.module.input.Variable', {
         type:         { init: null},
         units:        { init: null, nullable: true},
         order:        { init: null, nullable: true},
+        filter:       { init: null, nullable: true},
         desc:         { init: null, nullable: true},
         helpIcon:     { init: 'agrammon/info_s.png', nullable: true},
         helpFunction: { init: null, nullable: true}

--- a/frontend/source/class/agrammon/module/input/regional/ConfigEditor.js
+++ b/frontend/source/class/agrammon/module/input/regional/ConfigEditor.js
@@ -53,9 +53,8 @@ qx.Class.define('agrammon.module.input.regional.ConfigEditor', {
                 newData.push(rec);
                 if (! data[i].getName().match(/::ignore$/)
                     && data[i].getMetaData()['options']
-                    // Flattening/branching with only one option doesn't make sense.
-                    // This eliminates dummy select boxes used for filtering like animalcategory.
-                    && data[i].getMetaData()['options'].length > 1
+                    // Flattening/branching on the filter input (only animalcategory right now) doesn't make sense.
+                    && ! data[i].getFilter()
                     // TODO: remove
                     && data[i].getShow()
                    ) {
@@ -115,7 +114,8 @@ qx.Class.define('agrammon.module.input.regional.ConfigEditor', {
 
         },
 
-	    __storeData: function(msg) {
+        // TODO: remove? fz 2021-07-01
+	__storeData: function(msg) {
             var data = msg.getData();
             var varName = data['var'];
             var value   = data['value'];
@@ -134,7 +134,7 @@ qx.Class.define('agrammon.module.input.regional.ConfigEditor', {
                     row:         -1
                 }
             );
-	    },
+	},
 
         __update: function() {
             if (this.currentFolder != null) {

--- a/frontend/source/class/agrammon/module/input/regional/ConfigInstance.js
+++ b/frontend/source/class/agrammon/module/input/regional/ConfigInstance.js
@@ -22,7 +22,7 @@ qx.Class.define('agrammon.module.input.regional.ConfigInstance', {
         this.setLayout(new qx.ui.layout.VBox());
         this.__navTree = tree;
 
-            var height = qx.bom.Document.getHeight() - 20;
+        var height = qx.bom.Document.getHeight() - 20;
         this.set({ maxHeight: height, modal: true,
                   showClose: true, showMinimize: false, showMaximize: false,
 		          caption: this.tr("Configure instance")

--- a/frontend/source/class/agrammon/ui/table/rowrenderer/Fancy.js
+++ b/frontend/source/class/agrammon/ui/table/rowrenderer/Fancy.js
@@ -142,7 +142,7 @@ qx.Class.define('agrammon.ui.table.rowrenderer.Fancy', {
       }
 
       style.color = this._colors.colNormal;
-	  if ( rowInfo.rowData != undefined && (
+	  if (rowInfo.rowData != undefined && (
               rowInfo.rowData[5] === undefined
            || rowInfo.rowData[5] === '*** Select ***'
            || rowInfo.rowData[5] === null
@@ -190,7 +190,7 @@ qx.Class.define('agrammon.ui.table.rowrenderer.Fancy', {
       }
 
       rowStyle.push(';color:');
-	  if (    rowInfo.rowData[5] === undefined
+	  if (rowInfo.rowData[5] === undefined
            || rowInfo.rowData[5] === '*** Select ***'
            || rowInfo.rowData[5] === null
            || rowInfo.rowData[5] === ''

--- a/frontend/source/translation/de.po
+++ b/frontend/source/translation/de.po
@@ -102,7 +102,7 @@ msgstr "Datensatz"
 msgid "datasets"
 msgstr "Datensätze"
 
-#: agrammon/ui/menu/OptionMenu.js
+#: agrammon/module/input/NavBar.js
 msgid "Info"
 msgstr "Info"
 
@@ -162,7 +162,7 @@ msgstr "Datensatz"
 msgid "renamed to"
 msgstr "umbenannt in"
 
-#: agrammon/module/dataset/DatasetTool.js
+#: agrammon/module/input/NavBar.js
 msgid "Error"
 msgstr "Fehler"
 
@@ -174,7 +174,7 @@ msgstr "existiert bereits."
 msgid "Rename dataset"
 msgstr "Datensatz umbenennen"
 
-#: agrammon/module/dataset/DatasetTable.js
+#: agrammon/module/input/NavBar.js
 msgid "New name"
 msgstr "Neuer Name"
 
@@ -270,7 +270,7 @@ msgstr "Filter auf Marker Name"
 msgid "Input"
 msgstr "Eingabe"
 
-#: agrammon/module/input/regional/ConfigInstance.js
+#: agrammon/module/input/NavBar.js
 msgid "Instance name must not be empty."
 msgstr "Der Kategorie-Name darf nicht leer sein."
 
@@ -290,7 +290,7 @@ msgstr "Umbenennen Kategorie "
 msgid "Duplicate instance "
 msgstr "Duplizieren Kategorie "
 
-#: agrammon/ui/menu/NavMenu.js
+#: agrammon/module/input/NavBar.js
 msgid "Add instance"
 msgstr "Kategorie hinzufügen"
 
@@ -354,7 +354,7 @@ msgstr "Total"
 msgid "Branch configuration"
 msgstr "Branch-Konfiguration"
 
-#: agrammon/module/user/Account.js
+#: agrammon/module/output/SubmitWindow.js
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -602,7 +602,7 @@ msgstr "Passwort zurück setzen"
 msgid "Login"
 msgstr "Anmelden"
 
-#: agrammon/module/user/Account.js
+#: agrammon/ui/menu/AdminMenu.js
 msgid "Reset password"
 msgstr "Passwort zurücksetzen"
 

--- a/frontend/source/translation/en.po
+++ b/frontend/source/translation/en.po
@@ -58,7 +58,7 @@ msgstr ""
 msgid "Filter on dataset name"
 msgstr ""
 
-#: agrammon/module/dataset/DatasetCreate.js
+#: agrammon/module/dataset/DatasetTool.js
 msgid "Close"
 msgstr ""
 
@@ -110,7 +110,7 @@ msgstr ""
 msgid "datasets"
 msgstr ""
 
-#: agrammon/ui/menu/OptionMenu.js
+#: agrammon/module/input/NavBar.js
 msgid "Info"
 msgstr ""
 
@@ -170,7 +170,7 @@ msgstr ""
 msgid "renamed to"
 msgstr ""
 
-#: agrammon/module/dataset/DatasetTool.js
+#: agrammon/module/input/NavBar.js
 msgid "Error"
 msgstr ""
 
@@ -182,7 +182,7 @@ msgstr ""
 msgid "Rename dataset"
 msgstr ""
 
-#: agrammon/module/dataset/DatasetTable.js
+#: agrammon/module/input/NavBar.js
 msgid "New name"
 msgstr ""
 
@@ -278,7 +278,7 @@ msgstr ""
 msgid "Input"
 msgstr ""
 
-#: agrammon/module/input/regional/ConfigInstance.js
+#: agrammon/module/input/NavBar.js
 msgid "Instance name must not be empty."
 msgstr ""
 
@@ -298,7 +298,7 @@ msgstr ""
 msgid "Duplicate instance "
 msgstr ""
 
-#: agrammon/ui/menu/NavMenu.js
+#: agrammon/module/input/NavBar.js
 msgid "Add instance"
 msgstr ""
 
@@ -362,7 +362,7 @@ msgstr ""
 msgid "Branch configuration"
 msgstr ""
 
-#: agrammon/module/user/Account.js
+#: agrammon/module/output/SubmitWindow.js
 msgid "Cancel"
 msgstr ""
 
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: agrammon/module/user/Account.js
+#: agrammon/ui/menu/AdminMenu.js
 msgid "Reset password"
 msgstr ""
 

--- a/lib/Agrammon/Model/Input.pm6
+++ b/lib/Agrammon/Model/Input.pm6
@@ -82,6 +82,7 @@ class Agrammon::Model::Input {
                 gui  => $.default-gui,
             )),
             :enum(%!enum-lookup),
+            :$!filter,
             :%!help,
             :%!labels,
             :models(@!models || @("all")),

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/input_variables_entries_removed.sql
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/input_variables_entries_removed.sql
@@ -10,3 +10,8 @@ AND data_dataset IN (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0
 DELETE FROM data_new WHERE (data_var LIKE 'Livestock::DairyCow[]::Housing::Floor%' OR data_var LIKE 'Livestock::OtherCattle[]::Housing::Floor%')
 AND data_val = 'toothed_scrapper_running_over_a_grooved_floor'
 AND data_dataset IN (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+
+-- flattened
+DELETE FROM data_new WHERE (data_var LIKE 'Livestock::DairyCow[]::Housing::Floor%_toothed scrapper running over a grooved floor' OR data_var LIKE 'Livestock::OtherCattle[]::Housing::Floor%_toothed scrapper running over a grooved floor')
+AND data_dataset IN (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/input_variables_flattened.sql
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/input_variables_flattened.sql
@@ -1,0 +1,105 @@
+-- DairyCow, OtherCattle
+DELETE FROM data_new WHERE (data_var LIKE 'Livestock::DairyCow[]::Housing::Floor%_toothed scrapper running over a grooved floor' OR data_var LIKE 'Livestock::OtherCattle[]::Housing::Floor%_toothed scrapper running over a grooved floor')
+AND data_dataset IN (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+-- DairyCow
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Housing::Floor::mitigation_housing_floor_flattened00_none' WHERE data_var='Livestock::DairyCow[]::Housing::Floor::UNECE_category_1_mitigation_options_for_housing_systems_for_dairy_cows_flattened00_none'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Housing::Floor::mitigation_housing_floor_flattened01_raised feeding stands' WHERE data_var='Livestock::DairyCow[]::Housing::Floor::UNECE_category_1_mitigation_options_for_housing_systems_for_dairy_cows_flattened01_raised feeding stands'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Housing::Floor::mitigation_housing_floor_flattened02_floor with cross slope and collection gutter' WHERE data_var='Livestock::DairyCow[]::Housing::Floor::UNECE_category_1_mitigation_options_for_housing_systems_for_dairy_cows_flattened02_floor with cross slope and collection gutter'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Housing::Floor::mitigation_housing_floor_flattened03_floor with cross slope and collection gutter and raised feeding stands' WHERE data_var='Livestock::DairyCow[]::Housing::Floor::UNECE_category_1_mitigation_options_for_housing_systems_for_dairy_cows_flattened03_floor with cross slope and collection gutter and raised feeding stands'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Outdoor::floor_properties_exercise_yard_flattened00_solid floor' WHERE data_var='Livestock::DairyCow[]::Yard::floor_properties_exercise_yard_SHL_flattened00_solid floor'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Outdoor::floor_properties_exercise_yard_flattened01_unpaved floor' WHERE data_var='Livestock::DairyCow[]::Yard::floor_properties_exercise_yard_SHL_flattened01_unpaved floor'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Outdoor::floor_properties_exercise_yard_flattened02_perforated floor' WHERE data_var='Livestock::DairyCow[]::Yard::floor_properties_exercise_yard_SHL_flattened02_perforated floor'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Outdoor::floor_properties_exercise_yard_flattened03_paddock or pasture used as exercise yard' WHERE data_var='Livestock::DairyCow[]::Yard::floor_properties_exercise_yard_SHL_flattened03_paddock or pasture used as exercise yard'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Outdoor::exercise_yard_flattened00_not available' WHERE data_var='Livestock::DairyCow[]::Yard::exercise_yard_flattened00_not available'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Outdoor::exercise_yard_flattened01_available roughage is not supplied in the exercise yard' WHERE data_var='Livestock::DairyCow[]::Yard::exercise_yard_flattened01_available roughage is not supplied in the exercise yard'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Outdoor::exercise_yard_flattened02_available roughage is partly supplied in the exercise yard' WHERE data_var='Livestock::DairyCow[]::Yard::exercise_yard_flattened02_available roughage is partly supplied in the exercise yard'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::DairyCow[]::Outdoor::exercise_yard_flattened03_available roughage is exclusively supplied in the exercise yard' WHERE data_var='Livestock::DairyCow[]::Yard::exercise_yard_flattened03_available roughage is exclusively supplied in the exercise yard'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+
+-- OtherCattle
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Housing::Floor::mitigation_housing_floor_flattened00_none' WHERE data_var='Livestock::OtherCattle[]::Housing::Floor::UNECE_category_1_mitigation_options_for_housing_systems_for_other_cattle_flattened00_none'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Housing::Floor::mitigation_housing_floor_flattened01_raised feeding stands' WHERE data_var='Livestock::OtherCattle[]::Housing::Floor::UNECE_category_1_mitigation_options_for_housing_systems_for_other_cattle_flattened01_raised feeding stands'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Housing::Floor::mitigation_housing_floor_flattened02_floor with cross slope and collection gutter' WHERE data_var='Livestock::OtherCattle[]::Housing::Floor::UNECE_category_1_mitigation_options_for_housing_systems_for_other_cattle_flattened02_floor with cross slope and collection gutter'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Housing::Floor::mitigation_housing_floor_flattened03_floor with cross slope and collection gutter and raised feeding stands' WHERE data_var='Livestock::OtherCattle[]::Housing::Floor::UNECE_category_1_mitigation_options_for_housing_systems_for_other_cattle_flattened03_floor with cross slope and collection gutter and raised feeding stands'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Outdoor::floor_properties_exercise_yard_flattened00_solid floor' WHERE data_var='Livestock::OtherCattle[]::Yard::floor_properties_exercise_yard_SHL_flattened00_solid floor'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Outdoor::floor_properties_exercise_yard_flattened01_unpaved floor' WHERE data_var='Livestock::OtherCattle[]::Yard::floor_properties_exercise_yard_SHL_flattened01_unpaved floor'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Outdoor::floor_properties_exercise_yard_flattened02_perforated floor' WHERE data_var='Livestock::OtherCattle[]::Yard::floor_properties_exercise_yard_SHL_flattened02_perforated floor'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Outdoor::floor_properties_exercise_yard_flattened03_paddock or pasture used as exercise yard' WHERE data_var='Livestock::OtherCattle[]::Yard::floor_properties_exercise_yard_SHL_flattened03_paddock or pasture used as exercise yard'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Outdoor::exercise_yard_flattened00_not available' WHERE data_var='Livestock::OtherCattle[]::Yard::exercise_yard_flattened00_not available'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Outdoor::exercise_yard_flattened01_available roughage is not supplied in the exercise yard' WHERE data_var='Livestock::OtherCattle[]::Yard::exercise_yard_flattened01_available roughage is not supplied in the exercise yard'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Outdoor::exercise_yard_flattened02_available roughage is partly supplied in the exercise yard' WHERE data_var='Livestock::OtherCattle[]::Yard::exercise_yard_flattened02_available roughage is partly supplied in the exercise yard'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::OtherCattle[]::Outdoor::exercise_yard_flattened03_available roughage is exclusively supplied in the exercise yard' WHERE data_var='Livestock::OtherCattle[]::Yard::exercise_yard_flattened03_available roughage is exclusively supplied in the exercise yard'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+-- Pig
+
+UPDATE data_new SET data_val='none' WHERE data_var='Livestock::Pig[]::Housing::MitigationOptions::mitigation_housing_floor' AND data_val!='flattened'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0' AND dataset_model IN ('RegionalSHL') );
+UPDATE data_new SET data_var='Livestock::Pig[]::Housing::MitigationOptions::mitigation_housing_floor_flattened00_none', data_val=100 WHERE data_var='Livestock::Pig[]::Housing::MitigationOptions::UNECE_category_1_mitigation_options_for_housing_systems_for_pigs_flattened00_none'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+DELETE FROM data_new WHERE data_var LIKE 'Livestock::Pig[]::Housing::MitigationOptions::UNECE_category_1_mitigation_options_for_housing_systems_for_pigs_flattened%'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+
+UPDATE data_new SET data_var='Livestock::Pig[]::Housing::MitigationOptions::mitigation_housing_air_flattened00_none' WHERE data_var='Livestock::Pig[]::Housing::MitigationOptions::mitigation_options_for_housing_systems_for_pigs_air_flattened00_none'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::Pig[]::Housing::MitigationOptions::mitigation_housing_air_flattened01_low impuls air supply' WHERE data_var='Livestock::Pig[]::Housing::MitigationOptions::mitigation_options_for_housing_systems_for_pigs_air_flattened01_low impuls air supply'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+-- Fattening Pigs
+
+UPDATE data_new SET data_val='none' WHERE data_var='Livestock::FatteningPigs[]::Housing::MitigationOptions::mitigation_housing_floor' AND data_val!='flattened'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0' AND dataset_model IN ('RegionalSHL') );
+UPDATE data_new SET data_var='Livestock::FatteningPigs[]::Housing::MitigationOptions::mitigation_housing_floor_flattened00_none', data_val=100 WHERE data_var='Livestock::Pig[]::Housing::MitigationOptions::UNECE_category_1_mitigation_options_for_housing_systems_for_fattening_pigs_slurry_channel_flattened00_none'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+DELETE FROM data_new WHERE data_var LIKE 'Livestock::FatteningPigs[]::Housing::MitigationOptions::UNECE_category_1_mitigation_options_for_housing_systems_for_fattening_pigs_slurry_channel_flattened%'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+UPDATE data_new SET data_var='Livestock::FatteningPigs[]::Housing::MitigationOptions::mitigation_housing_air_flattened00_none' WHERE data_var='Livestock::FatteningPigs[]::Housing::MitigationOptions::mitigation_options_for_housing_systems_for_fattening_pigs_air_flattened00_none'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::FatteningPigs[]::Housing::MitigationOptions::mitigation_housing_air_flattened01_low impuls air supply' WHERE data_var='Livestock::FatteningPigs[]::Housing::MitigationOptions::mitigation_options_for_housing_systems_for_fattening_pigs_air_flattened01_low impuls air supply'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+-- Poultry
+
+UPDATE data_new SET data_var='Livestock::Poultry[]::Grazing::free_range_flattened00_yes' WHERE data_var='Livestock::Poultry[]::Outdoor::free_range_flattened00_yes'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::Poultry[]::Grazing::free_range_flattened01_no' WHERE data_var='Livestock::Poultry[]::Outdoor::free_range_flattened01_no'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+
+-- Equides
+
+UPDATE data_new SET data_var='Livestock::Equides[]::Outdoor::floor_properties_exercise_yard_flattened00_solid floor' WHERE data_var='Livestock::Equides[]::Yard::floor_properties_exercise_yard_SHL_flattened00_solid floor'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::Equides[]::Outdoor::floor_properties_exercise_yard_flattened01_unpaved floor' WHERE data_var='Livestock::Equides[]::Yard::floor_properties_exercise_yard_SHL_flattened01_unpaved floor'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');
+UPDATE data_new SET data_var='Livestock::Equides[]::Outdoor::floor_properties_exercise_yard_flattened02_paddock or pasture used as exercise yard' WHERE data_var='Livestock::Equides[]::Yard::floor_properties_exercise_yard_SHL_flattened02_paddock or pasture used as exercise yard'
+       AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version = '6.0');

--- a/t/test-data/Models/hr-inclNOxExtendedWithFilters/input_variables_rename_postdep.sql
+++ b/t/test-data/Models/hr-inclNOxExtendedWithFilters/input_variables_rename_postdep.sql
@@ -7,17 +7,20 @@ UPDATE data_new SET data_var='Livestock::FatteningPigs[]::Excretion::animals' WH
 -- Pig
 UPDATE data_new SET data_var='Livestock::Pig[]::Excretion::animals' WHERE data_var='Livestock::Pig[]::Excretion::pigs'
    AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version='6.0');
+
 -- Equides
 UPDATE data_new SET data_var='Livestock::Equides[]::Outdoor::grazing_hours' WHERE data_var='Livestock::Equides[]::GrazingInput::grazing_hours'
    AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version='6.0');
 UPDATE data_new SET data_var='Livestock::Equides[]::Outdoor::grazing_days' WHERE data_var='Livestock::Equides[]::GrazingInput::grazing_days'
    AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version='6.0');
+
 UPDATE data_new SET data_var='Livestock::Equides[]::Outdoor::yard_hours' WHERE data_var='Livestock::Equides[]::Yard::yard_hours'
    AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version='6.0');
 UPDATE data_new SET data_var='Livestock::Equides[]::Outdoor::yard_days' WHERE data_var='Livestock::Equides[]::Yard::yard_days'
    AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version='6.0');
 UPDATE data_new SET data_var='Livestock::Equides[]::Outdoor::floor_properties_exercise_yard' WHERE data_var='Livestock::Equides[]::Yard::floor_properties_exercise_yard'
    AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version='6.0');
+
 -- ?if !Kantonal_LU:
 UPDATE data_new SET data_var='Livestock::Equides[]::Outdoor::free_correction_factor' WHERE data_var='Livestock::Equides[]::Yard::free_correction_factor'
    AND data_dataset in (SELECT dataset_id FROM dataset WHERE dataset_version='6.0' AND dataset_modelvariant!='Kantonal_LU' AND dataset_modelvariant!='UNKNOWN');


### PR DESCRIPTION
- Allow branching/flattening only on inputs that are not filter values (e.g. not on `animalcategory`)
- Allow on single value enums
- Add SQL statements for flattened data migration
- Make newly created flattened inputs "``" instead of having default value (`*** Select ***`) set (hack needs to be fixed in frontend refactoring)
- Some minor obvious frontend cleanups