### PR TITLE
Make printf output more robust

### DIFF
--- a/lib/Agrammon/Performance.pm6
+++ b/lib/Agrammon/Performance.pm6
@@ -4,6 +4,6 @@ sub timed(Str $title, &proc) is export {
     my $start = now;
     my \ret   = proc;
     my $end   = now;
-    note sprintf "$title ran %.3f seconds", $end-$start;
+    note sprintf "%s ran %.3f seconds", $title, $end-$start;
     return ret;
 }


### PR DESCRIPTION
The old code blew up with `$title = 'foo 100% bar'`

The not so helpful error message was:
```
Your printf-style directives specify 2 arguments, but 1 argument was supplied.
Are you using an interpolated '$'?
[ERROR] 500 /get_output_variables - 10.34.12.100
```
More helpful would be if the format string was part of the output.