### PR TITLE
Add support for input default values calculated by a formula

### DIFF
--- a/lib/Agrammon/DataSource/DB.pm6
+++ b/lib/Agrammon/DataSource/DB.pm6
@@ -25,7 +25,7 @@ class Agrammon::DataSource::DB does Agrammon::DB {
     }
 
     # TODO: remove ignore condition after DB cleanup
-    method read($user, Str $dataset, %variant, %distribution-map) {
+    method read($user, Str $dataset, %variant) {
         self.with-db: -> $db {
             my $results = $db.query(q:to/STATEMENT/, $user, $dataset, %variant<version>, %variant<gui>, %variant<model>);
                 SELECT data_var, data_val, data_instance,
@@ -133,7 +133,7 @@ class Agrammon::DataSource::DB does Agrammon::DB {
                          .sub-taxonomy-b, .input-name-b, .input-values-b,
                          .matrix);
             }
-            return $dist-input.to-inputs(%distribution-map);
+            return $dist-input;
         }
     }
 }

--- a/lib/Agrammon/Environment.pm6
+++ b/lib/Agrammon/Environment.pm6
@@ -4,14 +4,13 @@ use Agrammon::Outputs;
 
 class Agrammon::Environment {
     has $.input;
-    has $.input-defaults;
     has $.technical;
     has $.technical-override;
     has Agrammon::Outputs::SingleOutputStorage $.output;
     has %.builtins;
 
     method get-input($name) {
-        $!input{$name} // $!input-defaults{$name}
+        $!input{$name}
     }
 
     method get-technical($name) {

--- a/lib/Agrammon/Formula/Builder.pm6
+++ b/lib/Agrammon/Formula/Builder.pm6
@@ -3,6 +3,8 @@ use Agrammon::Formula;
 use Agrammon::OutputReference;
 
 class Agrammon::Formula::Builder {
+    has Bool $.on-input;
+
     method TOP($/) {
         make Agrammon::Formula::Routine.new(
             statements => $<statementlist>.ast
@@ -164,6 +166,7 @@ class Agrammon::Formula::Builder {
     }
 
     method term:sym<Val>($/) {
+        self!no-input('Val');
         make Agrammon::Formula::Val.new(
             reference => Agrammon::OutputReference.new(
                 symbol => ~$<symbol>,
@@ -173,6 +176,7 @@ class Agrammon::Formula::Builder {
     }
 
     method term:sym<Out>($/) {
+        self!no-input('Out');
         make Agrammon::Formula::Val.new(
             reference => Agrammon::OutputReference.new(
                 symbol => ~$<symbol>,
@@ -182,12 +186,19 @@ class Agrammon::Formula::Builder {
     }
 
     method term:sym<Sum>($/) {
+        self!no-input('Sum');
         make Agrammon::Formula::Sum.new(
             reference => Agrammon::OutputReference.new(
                 symbol => ~$<symbol>,
                 module => $<module>.ast
             )
         );
+    }
+
+    method !no-input(Str $what) {
+        if $!on-input {
+            $/.panic("Cannot use $what on an input formula");
+        }
     }
 
     method term:sym<$TE>($/) {

--- a/lib/Agrammon/Formula/Parser.pm6
+++ b/lib/Agrammon/Formula/Parser.pm6
@@ -257,6 +257,7 @@ grammar Agrammon::Formula::Parser {
     }
 }
 
-sub parse-formula(Str $formula, Str $*CURRENT-MODULE) is export {
-    Agrammon::Formula::Parser.parse($formula, actions => Agrammon::Formula::Builder).ast
+sub parse-formula(Str $formula, Str $*CURRENT-MODULE, Bool :$on-input = False) is export {
+    my $actions = Agrammon::Formula::Builder.new(:$on-input);
+    Agrammon::Formula::Parser.parse($formula, :$actions).ast
 }

--- a/lib/Agrammon/Inputs.pm6
+++ b/lib/Agrammon/Inputs.pm6
@@ -1,5 +1,7 @@
 use v6;
 
+use Agrammon::Environment;
+
 class X::Agrammon::Inputs::AlreadySingle is Exception {
     has Str $.taxonomy;
     method message() {
@@ -74,6 +76,12 @@ role Agrammon::Inputs::Storage {
                 for $module.input -> $input {
                     with $input.default-calc {
                         %values{$input.name} //= $_;
+                    }
+                    orwith $input.compiled-default-formula -> &default {
+                        %values{$input.name} //= default(Agrammon::Environment.new(
+                                input => %values,
+                                technical => $module.technical-hash,
+                                technical-override => %technical{$taxonomy}))
                     }
                 }
             }

--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -127,7 +127,6 @@ class Agrammon::Model {
             my $*AGRAMMON-TAXONOMY = my $tax = $!module.taxonomy;
             my $env = Agrammon::Environment.new(
                 input => $input.input-hash-for($tax),
-                input-defaults => $!module.input-defaults,
                 technical => $!module.technical-hash,
                 technical-override => %technical{$tax},
                 output => $outputs
@@ -192,10 +191,9 @@ class Agrammon::Model {
                 $dep!annotate-inputs-internal($input-data, %run-already, @result, $instance-id);
             }
             my %input-data := $input-data.input-hash-for($!module.taxonomy);
-            my %input-defaults := $!module.input-defaults;
             for $!module.input -> Agrammon::Model::Input $input {
                 my $key   = $input.name;
-                my $value = %input-data{$key} // %input-defaults{$key};
+                my $value = %input-data{$key};
                 @result.push: AnnotatedInput.new: :$!module, :$input, :$instance-id, :$value, :%gui-root;
             }
         }

--- a/lib/Agrammon/Model/Input.pm6
+++ b/lib/Agrammon/Model/Input.pm6
@@ -1,11 +1,15 @@
 use v6;
 
+use Agrammon::Formula;
+use Agrammon::Formula::Compiler;
 use Agrammon::LanguageParser;
 
 class Agrammon::Model::Input {
     has Str $.name;
     has Str $.description;
     has     $.default-calc;
+    has Agrammon::Formula $.default-formula;
+    has     &.compiled-default-formula;
     has     $.default-gui;
     has Str $.type;         # XXX Should be something richer than Str
     has Str $.validator;    # XXX Should be something richer than Str
@@ -23,9 +27,14 @@ class Agrammon::Model::Input {
     has Bool $!distribute = False;
     has Bool $!filter = False;
 
-    submethod TWEAK(:$default_calc, :$default_gui, :$distribute, :$filter, :@enum --> Nil) {
+    submethod TWEAK(:$default_calc, :$default_gui, :$default_formula, :$default_formula_code,
+                    :$distribute, :$filter, :@enum --> Nil) {
         with $default_calc {
             $!default-calc = val($_);
+        }
+        with $default_formula {
+            $!default-formula = $default_formula;
+            &!compiled-default-formula = compile-formula($default_formula);
         }
         with $default_gui {
             $!default-gui = val($_);

--- a/lib/Agrammon/Model/Module.pm6
+++ b/lib/Agrammon/Model/Module.pm6
@@ -22,7 +22,6 @@ class Agrammon::Model::Module {
     has Agrammon::Model::Result @.results;
     has Str $.name;
     has Str $.parent;
-    has %.input-defaults; # for calculations
     has %.gui-defaults;   # for display in GUI
     has %.technical-hash;
     has $.instance-root;
@@ -39,7 +38,6 @@ class Agrammon::Model::Module {
             $!parent = '';
             $!name   = ~$tax;
         }
-        %!input-defaults = @!input.grep(*.default-calc.defined).map({ .name => .default-calc });
         %!gui-defaults   = @!input.grep(*.default-gui.defined).map({ .name => .default-gui });
         %!technical-hash = @!technical.map({ .name => .value });
     }
@@ -51,7 +49,4 @@ class Agrammon::Model::Module {
     method set-instance-root(Str $!instance-root) {}
 
     method set-gui-root(Agrammon::Model::Module $!gui-root-module) {}
-
 }
-
-

--- a/lib/Agrammon/ModuleBuilder.pm6
+++ b/lib/Agrammon/ModuleBuilder.pm6
@@ -35,7 +35,22 @@ class Agrammon::ModuleBuilder {
 
     method section:sym<input>($/) {
         make 'input' => $<input>.map({
-            Agrammon::Model::Input.new(|.ast)
+            my %input-props := .ast;
+            with %input-props<default_formula> <-> $formula {
+                with $*TAXONOMY -> $taxonomy {
+                    $formula = parse-formula($formula, $taxonomy, :on-input);
+                    CATCH {
+                        default {
+                            die "Error compiling default_formula for input '%input-props<name>' " ~
+                                    "in $taxonomy: $_";
+                        }
+                    }
+                }
+                else {
+                    die "Missing taxonomy in general section, or general section too late";
+                }
+            }
+            Agrammon::Model::Input.new(|%input-props)
         });
     }
 

--- a/lib/Agrammon/UI/CommandLine.pm6
+++ b/lib/Agrammon/UI/CommandLine.pm6
@@ -238,6 +238,7 @@ sub run (Str $model-filename, IO::Path $input-path, $technical-file, $variants, 
         }
         else {
             my $outputs = timed "$my-n: Run $input-path", {
+                $input.apply-defaults($model, %technical);
                 $model.run(:$input, :%technical);
             }
 

--- a/lib/Agrammon/Validation.pm6
+++ b/lib/Agrammon/Validation.pm6
@@ -203,7 +203,7 @@ sub check-module-inputs(Agrammon::Model::Module $module, %inputs is copy, @probl
             }
         }
         else {
-            without $input.default-calc {
+            without $input.default-calc orelse $input.default-formula {
                 @problems.push: MissingInput.new(:module($module.taxonomy), :$instance, :input($input.name));
             }
         }

--- a/lib/Agrammon/Web/Service.pm6
+++ b/lib/Agrammon/Web/Service.pm6
@@ -194,7 +194,10 @@ class Agrammon::Web::Service {
     }
 
     method !get-inputs($user, $dataset-name) {
-        Agrammon::DataSource::DB.new.read($user.username, $dataset-name, $!cfg.agrammon-variant, $!model.distribution-map);
+        my $input-dist = Agrammon::DataSource::DB.new.read($user.username, $dataset-name,
+                $!cfg.agrammon-variant);
+        $input-dist.apply-defaults($!model, %!technical-parameters);
+        $input-dist.to-inputs($!model.distribution-map)
     }
 
     method !get-outputs(Agrammon::Web::SessionUser $user, Str $dataset-name) {
@@ -315,6 +318,7 @@ class Agrammon::Web::Service {
             }
         }
 
+        $input.apply-defaults($model, %technical);
         my $outputs = $!model.run(:$input, :%technical);
 
         my @print-set = ($print-only).split(',') if $print-only;

--- a/t/datasource-db.t
+++ b/t/datasource-db.t
@@ -47,10 +47,8 @@ transactionally {
     my $dataset = $ds.read(
         $ag-user,
         $ag-dataset,
-        %single,
-        {}
-    );
-    isa-ok $dataset, Agrammon::Inputs, 'Correct type';
+        %single);
+    isa-ok $dataset, Agrammon::Inputs::Distribution, 'Correct type';
     is $dataset.simulation-name, 'DB', 'Correct simulation name';
     is $dataset.dataset-id, $ag-dataset, 'Correct data set ID';
 }
@@ -60,15 +58,10 @@ transactionally {
     lives-ok { prepare-test-db-flattened-data($ag-user, $ag-dataset, %regional) }, 'Flattened test database prepared';
 
         my $ds = Agrammon::DataSource::DB.new;
-        my $dataset = $ds.read(
-            $ag-user,
-            $ag-dataset,
-            %regional,
-            {
-                'Test::Base' => ['Test::Base::Sub::dist-me'],
-                'Test::Base2' => ['Test::Base2::Sub::dist-meA', 'Test::Base2::Sub::dist-meB']
-            }
-        );
+        my $dataset = $ds.read($ag-user, $ag-dataset, %regional).to-inputs({
+            'Test::Base' => ['Test::Base::Sub::dist-me'],
+            'Test::Base2' => ['Test::Base2::Sub::dist-meA', 'Test::Base2::Sub::dist-meB']
+        });
         isa-ok $dataset, Agrammon::Inputs, 'Correct type';
         is $dataset.simulation-name, 'DB', 'Correct simulation name';
         is $dataset.dataset-id, $ag-dataset, 'Correct data set ID';
@@ -126,10 +119,7 @@ transactionally {
     lives-ok { prepare-test-db-branched-data($ag-user, $ag-dataset, %regional) }, 'Branched test database prepared';
 
     my $ds = Agrammon::DataSource::DB.new;
-    my $dataset = $ds.read(
-        $ag-user,
-        $ag-dataset,
-        %regional,
+    my $dataset = $ds.read($ag-user, $ag-dataset, %regional).to-inputs(
         { 'Test::Base' => ['Test::Base::Sub::dist-me'] }
     );
     isa-ok $dataset, Agrammon::Inputs, 'Correct type';

--- a/t/input-default-formula.t
+++ b/t/input-default-formula.t
@@ -1,0 +1,36 @@
+use Agrammon::Model;
+use Test;
+
+my $path = $*PROGRAM.parent.add('test-data/Models/defaults');
+my $model = Agrammon::Model.new(:$path);
+$model.load('Top');
+
+my $input = Agrammon::Inputs.new;
+$input.add-single-input('Top', 'input1', 42);
+$input.add-multi-input('Sub', 'Instance1', '', 'input1', 10);
+$input.add-multi-input('Sub', 'Instance2', '', 'input1', 20);
+lives-ok { $input.apply-defaults($model, {}) },
+        'Can apply defaults to inputs when there are formulas';
+
+my %outputs = $model.run(:$input).get-outputs-hash();
+
+subtest 'Single instance module with input defaults' => {
+    given %outputs<Top> {
+        is .<output1>, 42, 'Directly provided input works';
+        is .<output2>, 84, 'Input default calculated from another input works';
+        is .<output3>, 215, 'Input calculated from a technical works';
+    }
+}
+
+subtest 'Multi instance module with input defaults' => {
+    given %outputs<Sub>.first(*.key eq 'Instance1').value<Sub> {
+        is .<output1>, 10, 'Directly provided input works (instance 1)';
+        is .<output2>, 50, 'Input default calculated from another input works (instance 1)';
+    }
+    given %outputs<Sub>.first(*.key eq 'Instance2').value<Sub> {
+        is .<output1>, 20, 'Directly provided input works (instance 1)';
+        is .<output2>, 100, 'Input default calculated from another input works (instance 1)';
+    }
+}
+
+done-testing;

--- a/t/model-with-filters.t
+++ b/t/model-with-filters.t
@@ -59,15 +59,19 @@ subtest 'Running the model produces output instances with filters' => {
     note sprintf "Parameters loaded in %.3f seconds", $end-$start;
     isa-ok $params, Agrammon::Model::Parameters, 'Correct type for technical data';
 
+    my %technical = $params.technical.map: -> %module {
+        %module.keys[0] => %(%module.values[0].map({ .name => .value }))
+    }
+    lives-ok { @datasets>>.apply-defaults($model, %technical) },
+        'Could apply defaults to inputs';
+
     my Agrammon::Outputs $output;
     $start = now;
     lives-ok
             {
-                $output = $model.run(
+                $output = $model.run:
                         input => @datasets[0],
-                        technical => %($params.technical.map(-> %module {
-                            %module.keys[0] => %(%module.values[0].map({ .name => .value }))
-                        })))
+                        technical => %technical
             },
             'Successfully executed model';
     $end   = now;

--- a/t/run-complex-model-with-filters.t
+++ b/t/run-complex-model-with-filters.t
@@ -61,13 +61,17 @@ for <hr-inclNOxExtended hr-inclNOxExtendedWithFilters> -> $model-version {
                 .slurp) },
                 'Parsed technical file';
         isa-ok $params, Agrammon::Model::Parameters, 'Correct type for technical data';
+
+        my %technical = $params.technical.map: -> %module {
+            %module.keys[0] => %(%module.values[0].map({ .name => .value }))
+        }
+        @datasets[0].apply-defaults($model, %technical);
+
         lives-ok
                 {
                     $output = $model.run(
                             input => @datasets[0],
-                            technical => %($params.technical.map(-> %module {
-                                %module.keys[0] => %(%module.values[0].map({ .name => .value }))
-                            }))
+                            technical => %technical
                     )
                 },
                 'Successfully executed model';

--- a/t/run-complex-model.t
+++ b/t/run-complex-model.t
@@ -22,14 +22,18 @@ lives-ok
     'Parsed technical file';
 isa-ok $params, Agrammon::Model::Parameters, 'Correct type for technical data';
 
+my %technical = $params.technical.map: -> %module {
+    %module.keys[0] => %(%module.values[0].map({ .name => .value }))
+}
+lives-ok { @datasets>>.apply-defaults($model, %technical) },
+    'Can apply default values to inputs for all datasets';
+
 my %output;
 lives-ok
     {
         %output = $model.run(
             input => @datasets[0],
-            technical => %($params.technical.map(-> %module {
-                %module.keys[0] => %(%module.values[0].map({ .name => .value }))
-            }))
+            technical => %technical
         ).get-outputs-hash()
     },
     'Successfully executed model';

--- a/t/run-simple-model.t
+++ b/t/run-simple-model.t
@@ -45,6 +45,7 @@ subtest 'Run with technical values overrides' => {
 subtest 'Run with missing input, which should use default calculation value' => {
     my $input = Agrammon::Inputs.new;
     $input.add-single-input('Test', 'final_add', 10);
+    $input.apply-defaults($model, {});
     my %outputs = $model.run(:$input).get-outputs-hash();
     ok %outputs<Test::SubModule>:exists, 'Have outputs hash for Test::SubModule';
     is %outputs<Test::SubModule><sub_result>, 20 * 5,

--- a/t/test-data/Models/defaults/Sub.nhd
+++ b/t/test-data/Models/defaults/Sub.nhd
@@ -1,0 +1,68 @@
+*** general ***
+
+author   = Jonathan Worthington
+date     = 2021-00-03
+taxonomy = Sub
+instances = multi
+
++short
+
+  For testing.
+
++description
+
+  Test description.
+
+*** input ***
+
++input1
+  type = integer
+  ++labels
+    en = Input1
+    de = Eingabe1
+  ++units
+    en = -
+  ++description
+    Test input1
+  ++help
+    +++en
+       <p>Test input1</p>
+    +++de
+       <p>Test Eingabe1</p>
+
++input2
+  type = integer
+  ++default_formula
+    In(input1) * 5
+  ++labels
+    en = Input2
+    de = Eingabe2
+  ++units
+    en = -
+  ++description
+    Test input2
+  ++help
+    +++en
+       <p>Test input2</p>
+    +++de
+       <p>Test Eingabe2</p>
+
+*** output ***
+
++output1
+  ++units
+    en = kg N/year
+    de = kg N/Jahr
+  ++formula
+    In(input1);
+  ++description
+    output1
+
++output2
+  ++units
+    en = kg N/year
+    de = kg N/Jahr
+  ++formula
+    In(input2);
+  ++description
+    output2

--- a/t/test-data/Models/defaults/Top.nhd
+++ b/t/test-data/Models/defaults/Top.nhd
@@ -1,0 +1,108 @@
+*** general ***
+
+author   = Jonathan Worthington
+date     = 2021-00-03
+taxonomy = Top
+
++short
+
+  For testing.
+
++description
+
+  Test description.
+
+*** input ***
+
++input1
+  type = integer
+  ++labels
+    en = Input1
+    de = Eingabe1
+  ++units
+    en = -
+  ++description
+    Test input1
+  ++help
+    +++en
+       <p>Test input1</p>
+    +++de
+       <p>Test Eingabe1</p>
+
++input2
+  type = integer
+  ++default_formula
+    In(input1) * 2
+  ++labels
+    en = Input2
+    de = Eingabe2
+  ++units
+    en = -
+  ++description
+    Test input2
+  ++help
+    +++en
+       <p>Test input2</p>
+    +++de
+       <p>Test Eingabe2</p>
+
++input3
+  type = integer
+  ++default_formula
+    Tech(tech1) + 100
+  ++labels
+    en = Input3
+    de = Eingabe3
+  ++units
+    en = -
+  ++description
+    Test input3
+  ++help
+    +++en
+       <p>Test input3</p>
+    +++de
+       <p>Test Eingabe3</p>
+
+*** technical ***
+
++tech1
+  value = 115
+  ++units
+    en = kg N/year
+    de = kg N/Jahr
+  ++description
+    tech1 parameter
+
+*** external ***
+
++Sub
+  aggregate=SUM
+
+*** output ***
+
++output1
+  ++units
+    en = kg N/year
+    de = kg N/Jahr
+  ++formula
+    In(input1);
+  ++description
+    output1
+
++output2
+  ++units
+    en = kg N/year
+    de = kg N/Jahr
+  ++formula
+    In(input2);
+  ++description
+    output2
+
++output3
+  ++units
+    en = kg N/year
+    de = kg N/Jahr
+  ++formula
+    In(input3);
+  ++description
+    output3


### PR DESCRIPTION
This adds a `default_formula` value to inputs that can be set to a formula that will be evaluated in order to provide the default value. It may refer to other inputs and also to technical parameters; `Val`, `Out`, and `Sum` are forbidden, however. Further to this, the way defaults are handled is refactored, and application of them is now done (including evaluating the new default formulas) after inputs are loaded, but - in the case of the DB datasource - before we perform branching and flattening, so that defaults may be distributed as part of the branching and flattening too.