### PR TITLE
Allow none-integer distributable values

### DIFF
--- a/lib/Agrammon/Inputs.pm6
+++ b/lib/Agrammon/Inputs.pm6
@@ -367,7 +367,7 @@ class Agrammon::Inputs::Distribution does Agrammon::Inputs::Storage {
         my class DistributableValue {
             has Str $.dist-name is required;
             has Str $.dist-sub-taxonomy is required;
-            has Int $.dist-total is required;
+            has Numeric $.dist-total is required;
         }
         my @distributable-values;
         for @distribute-over -> $dist-over {


### PR DESCRIPTION
In the regional model, the customer wants to allow none-integer "number of animals or staple places".
This was implemented in the model already, but apparently not used so far and currently fails as `dist-total` is enforced to be `Int`. Change to `Numeric`.