### PR TITLE
Integrate input default formulas with model cache

### DIFF
--- a/lib/Agrammon/Model.pm6
+++ b/lib/Agrammon/Model.pm6
@@ -354,15 +354,28 @@ class Agrammon::Model {
     }
 
     method !compile-formulas() {
-        my @output-order;
+        my @targets;
         my @formula-sources;
-        for @!evaluation-order.map(*.output).flat -> $output {
-            push @output-order, $output;
-            push @formula-sources, compile-formula-to-source($output.formula);
+        for @!evaluation-order -> $module {
+            for $module.input -> $input {
+                with $input.default-formula {
+                    push @targets, $input;
+                    push @formula-sources, compile-formula-to-source($input.default-formula);
+                }
+            }
+            for $module.output -> $output {
+                push @targets, $output;
+                push @formula-sources, compile-formula-to-source($output.formula);
+            }
         }
         use MONKEY-SEE-NO-EVAL;
-        for flat @output-order Z EVAL(@formula-sources.join(',')) -> $output, $compiled {
-            $output.compiled-formula = $compiled;
+        for flat @targets Z EVAL(@formula-sources.join(',')) -> $_, $compiled {
+            when Agrammon::Model::Output {
+                .compiled-formula = $compiled;
+            }
+            when Agrammon::Model::Input {
+                .compiled-default-formula = $compiled;
+            }
         }
     }
 

--- a/lib/Agrammon/Model/Input.pm6
+++ b/lib/Agrammon/Model/Input.pm6
@@ -9,7 +9,7 @@ class Agrammon::Model::Input {
     has Str $.description;
     has     $.default-calc;
     has Agrammon::Formula $.default-formula;
-    has     &.compiled-default-formula;
+    has     &.compiled-default-formula is rw;
     has     $.default-gui;
     has Str $.type;         # XXX Should be something richer than Str
     has Str $.validator;    # XXX Should be something richer than Str
@@ -34,7 +34,6 @@ class Agrammon::Model::Input {
         }
         with $default_formula {
             $!default-formula = $default_formula;
-            &!compiled-default-formula = compile-formula($default_formula);
         }
         with $default_gui {
             $!default-gui = val($_);

--- a/lib/Agrammon/ModelCache.pm6
+++ b/lib/Agrammon/ModelCache.pm6
@@ -57,6 +57,12 @@ sub hash-model($base, %preprocessor-options) {
 sub set-formulas-code(Agrammon::Model $model) {
     my @formula-set-lines;
     for $model.evaluation-order.kv -> $midx, $module {
+        for $module.input.kv -> $iidx, Agrammon::Model::Input $input {
+            with $input.default-formula {
+                my $source = compile-formula-to-source($_);
+                push @formula-set-lines, q:c'@modules[{$midx}].input[{$iidx}].compiled-default-formula = {$source}';
+            }
+        }
         for $module.output.kv -> $oidx, $output {
             my $source = compile-formula-to-source($output.formula);
             push @formula-set-lines, q:c'@modules[{$midx}].output[{$oidx}].compiled-formula = {$source}';


### PR DESCRIPTION
I cheated on this, thinking it would only cost us perhaps a tiny bit of
performance (but not much as default input formulas would be rare). I
was wrong; the model caching scheme really needs us to do all of the
formula compilation - including default formulas - its way, otherwise we
end up with breakage. Thus, adopt the same approach taken to compiling
other formulas for compiling input default formulas too.