### PR TITLE
RT53007: remove default_calc on selectBox

### DIFF
--- a/dev/META6.json
+++ b/dev/META6.json
@@ -53,6 +53,7 @@
     "Agrammon::DB::Variant": "lib/Agrammon/DB/Variant.pm6",
     "Agrammon::DataSource::CSV": "lib/Agrammon/DataSource/CSV.pm6",
     "Agrammon::DataSource::DB": "lib/Agrammon/DataSource/DB.pm6",
+    "Agrammon::DataSource::Util": "lib/Agrammon/DataSource/Util.pm6",
     "Agrammon::Environment": "lib/Agrammon/Environment.pm6",
     "Agrammon::Formula": "lib/Agrammon/Formula.pm6",
     "Agrammon::Formula::Builder": "lib/Agrammon/Formula/Builder.pm6",

--- a/share/Models/version6/Livestock/DairyCow/Housing/Floor.nhd
+++ b/share/Models/version6/Livestock/DairyCow/Housing/Floor.nhd
@@ -23,7 +23,6 @@ UNECE 2007. Guidance document on control techniques for preventing and abating e
 
 +mitigation_housing_floor
   type  = enum
-  default_calc = none
   ++enum
     +++none
        en = none
@@ -107,6 +106,7 @@ UNECE 2007. Guidance document on control techniques for preventing and abating e
     Correction factor for the emission due to the use of a grooved floor in housing systems.
   ++formula
     # TODO: is next line correct? Was missing compared to OtherCattle
+    warn "### mitigation_housing_floor=", (In(mitigation_housing_floor) // 0);
     return 1 unless defined In(mitigation_housing_floor);
     given ( In(mitigation_housing_floor) ) {
       when 'raised_feeding_stands' {

--- a/share/Models/version6/Livestock/OtherCattle/Housing/Floor.nhd
+++ b/share/Models/version6/Livestock/OtherCattle/Housing/Floor.nhd
@@ -22,7 +22,6 @@ UNECE 2007. Guidance document on control techniques for preventing and abating e
 
 +mitigation_housing_floor
   type  = enum
-  default_calc = none
   ++enum
     +++none
        en =none


### PR DESCRIPTION
`default_calc = none` on the selectBox for `mitigation_housing_floor` effectively forced this value on flattened instances overriding the real value.

**NOTE: ** `default_calc` must not be used on SelectBoxes with more than one item.