### PR TITLE
Remove default_calc for selection (#539)

### DIFF
--- a/share/Models/version6/Application/Slurry/Csoft.nhd
+++ b/share/Models/version6/Application/Slurry/Csoft.nhd
@@ -48,7 +48,6 @@ taxonomy = Application::Slurry::Csoft
    
   +appl_hotdays
     type  = enum
-    default_calc = sometimes
     ++enum
       +++frequently
          en = frequently

--- a/share/Models/version6/Livestock/DairyCow/Outdoor.nhd
+++ b/share/Models/version6/Livestock/DairyCow/Outdoor.nhd
@@ -84,7 +84,6 @@ taxonomy = Livestock::DairyCow::Outdoor
 
 +floor_properties_exercise_yard
   type  = enum
-  default_calc = solid_floor
   ++enum
      +++solid_floor
        en = solid_floor

--- a/share/Models/version6/Livestock/Equides/Outdoor.nhd
+++ b/share/Models/version6/Livestock/Equides/Outdoor.nhd
@@ -105,7 +105,6 @@ taxonomy = Livestock::Equides::Outdoor
 
 +floor_properties_exercise_yard
   type  = enum
-  default_calc = solid_floor
   ++enum
     +++solid_floor
        en = solid_floor

--- a/share/Models/version6/Livestock/FatteningPigs/Housing/MitigationOptions.nhd
+++ b/share/Models/version6/Livestock/FatteningPigs/Housing/MitigationOptions.nhd
@@ -46,7 +46,6 @@ UNECE 2007. Guidance document on control techniques for preventing and abating e
 
 +mitigation_housing_air
   type  = enum
-  default_calc = none
   ++enum
     +++none
        en = none

--- a/share/Models/version6/Livestock/FatteningPigs/Housing/MitigationOptions.nhd
+++ b/share/Models/version6/Livestock/FatteningPigs/Housing/MitigationOptions.nhd
@@ -21,6 +21,7 @@ UNECE 2007. Guidance document on control techniques for preventing and abating e
 +mitigation_housing_floor
   type  = enum
   default_calc = none
+  default_gui = none
   ++enum
     +++none
        en = none

--- a/share/Models/version6/Livestock/OtherCattle/Outdoor.nhd
+++ b/share/Models/version6/Livestock/OtherCattle/Outdoor.nhd
@@ -281,7 +281,6 @@ taxonomy = Livestock::OtherCattle::Outdoor
 
 +floor_properties_exercise_yard
   type  = enum
-  default_calc = solid_floor
   ++enum
      +++solid_floor
        en = solid_floor

--- a/share/Models/version6/Livestock/Pig/Housing/MitigationOptions.nhd
+++ b/share/Models/version6/Livestock/Pig/Housing/MitigationOptions.nhd
@@ -46,7 +46,6 @@ UNECE 2007. Guidance document on control techniques for preventing and abating e
 
 +mitigation_housing_air
   type  = enum
-  default_calc = none
   ++enum
     +++none
        en = none

--- a/share/Models/version6/Livestock/Pig/Housing/MitigationOptions.nhd
+++ b/share/Models/version6/Livestock/Pig/Housing/MitigationOptions.nhd
@@ -21,6 +21,7 @@ UNECE 2007. Guidance document on control techniques for preventing and abating e
 +mitigation_housing_floor
   type  = enum
   default_calc = none
+  default_gui = none
   ++enum
     +++none
        en = none


### PR DESCRIPTION
`default_calc` can't be set for input variables with `enum` selection

see issue #539 