### PR TITLE
Implement `for` loops and array literals

### DIFF
--- a/lib/Agrammon/Environment.rakumod
+++ b/lib/Agrammon/Environment.rakumod
@@ -20,4 +20,8 @@ class Agrammon::Environment {
     method find-builtin($name) {
         %!builtins{$name} // get-builtins(){$name} // die "No such builtin function '$name'";
     }
+
+    method iterate($value) {
+        $value ~~ Map ?? $value.kv !! $value.list
+    }
 }

--- a/lib/Agrammon/Formula/Builder.rakumod
+++ b/lib/Agrammon/Formula/Builder.rakumod
@@ -97,6 +97,13 @@ class Agrammon::Formula::Builder {
         )
     }
 
+    method statement_control:sym<for>($/) {
+        make Agrammon::Formula::For.new(
+            iterable => $<EXPR>.ast,
+            loop-vars => $<variable>.map(-> $var { Agrammon::Formula::VarDecl.new(name => ~$var) }),
+            block => $<block>.ast
+        );
+    }
 
     method block($/) {
         make Agrammon::Formula::Block.new(
@@ -260,6 +267,12 @@ class Agrammon::Formula::Builder {
 
     method term:sym<( )>($/) {
         make $<EXPR>.ast;
+    }
+
+    method term:sym<[ ]>($/) {
+        make Agrammon::Formula::Array.new(
+            values => $<EXPR>.map(*.ast)
+        );
     }
 
     method term:sym<{ }>($/) {

--- a/lib/Agrammon/Formula/Compiler.rakumod
+++ b/lib/Agrammon/Formula/Compiler.rakumod
@@ -41,6 +41,12 @@ multi compile(Agrammon::Formula::Default $default) {
     q:f"default { &compile($default.block) }"
 }
 
+multi compile(Agrammon::Formula::For $for) {
+    q:f"for $env.iterate(&compile($for.iterable)) -> " ~
+        $for.loop-vars.map(*.name).join(", ") ~
+        q:f" { &compile($for.block) }"
+}
+
 multi compile(Agrammon::Formula::WhenMod $when) {
     q:f"&compile($when.then) when &compile($when.test)"
 }
@@ -67,6 +73,10 @@ multi compile(Agrammon::Formula::Sum $sum) {
     given $sum.reference {
         q:c"$env.output.get-sum('{.module}', '{.symbol}')"
     }
+}
+
+multi compile(Agrammon::Formula::Array $array) {
+    q:c"@( {$array.values.map(&compile).join(',')} )"
 }
 
 multi compile(Agrammon::Formula::Hash $hash) {

--- a/lib/Agrammon/Formula/Parser.rakumod
+++ b/lib/Agrammon/Formula/Parser.rakumod
@@ -64,6 +64,13 @@ grammar Agrammon::Formula::Parser {
         'default' <block>
     }
 
+    rule statement_control:sym<for> {
+        'for'
+        [ '(' <EXPR> ')' || <.panic('Missing or malformed loop expression')> ]
+        ['->' <variable>+ % [ ',' ] || <.panic('Missing or malformed loop variables')> ]
+        <block>
+    }
+
     rule block {
         [ '{' || <.panic('Expected block')> ]
         <statementlist>
@@ -150,6 +157,12 @@ grammar Agrammon::Formula::Parser {
 
     rule term:sym<( )> {
         '(' <EXPR> [ ')' || <.panic('Missing closing )')> ]
+    }
+
+    rule term:sym<[ ]> {
+        '['
+        <EXPR>* %% [ ',' ]
+        [ ']' || <.panic('Missing ] on array literal or malformed array')> ]
     }
 
     rule term:sym<{ }> {

--- a/t/formula.rakutest
+++ b/t/formula.rakutest
@@ -1098,4 +1098,124 @@ subtest {
     is $result.Numeric, 42, 'Correct result';
 }, 'P+ upgrades scalar value on left side';
 
+subtest {
+    my $f = parse-formula(q:to/FORMULA/, 'TestModule');
+        my $total = 0;
+        for ([1, 2, 3]) -> $num {
+            $total = $total + $num;
+        }
+        return $total;
+        FORMULA
+    ok $f ~~ Agrammon::Formula, 'Get something doing Agrammon::Formula from parse';
+    is-deeply $f.input-used, (), 'Correct inputs-used';
+    is-deeply $f.technical-used, (), 'Correct technical-used';
+    is-deeply $f.output-used, (), 'Correct output-used';
+    my $result = compile-and-evaluate($f, Agrammon::Environment.new);
+    is $result, 6, 'Correct result from for loop over array literal';
+}, 'Basic for loop over array literal';
+
+subtest {
+    my $f = parse-formula(q:to/FORMULA/, 'TestModule');
+        my $nums = [1, 2, 3];
+        my $total = 0;
+        for ($nums) -> $num {
+            $total = $total + $num;
+        }
+        return $total;
+        FORMULA
+    ok $f ~~ Agrammon::Formula, 'Get something doing Agrammon::Formula from parse';
+    is-deeply $f.input-used, (), 'Correct inputs-used';
+    is-deeply $f.technical-used, (), 'Correct technical-used';
+    is-deeply $f.output-used, (), 'Correct output-used';
+    my $result = compile-and-evaluate($f, Agrammon::Environment.new);
+    is $result, 6, 'Correct result from for loop over variable';
+}, 'For loop over variable containing array';
+
+subtest {
+    my $f = parse-formula(q:to/FORMULA/, 'TestModule');
+        my $total = 0;
+        for ([3, 5, 7, 9]) -> $a, $b {
+            $total = $total + $a * $b;
+        }
+        return $total;
+        FORMULA
+    ok $f ~~ Agrammon::Formula, 'Get something doing Agrammon::Formula from parse';
+    is-deeply $f.input-used, (), 'Correct inputs-used';
+    is-deeply $f.technical-used, (), 'Correct technical-used';
+    is-deeply $f.output-used, (), 'Correct output-used';
+    my $result = compile-and-evaluate($f, Agrammon::Environment.new);
+    is $result, 3*5 + 7*9, 'Correct result from for loop taking two values at a time';
+}, 'For loop taking two values at a time';
+
+subtest {
+    my $f = parse-formula(q:to/FORMULA/, 'TestModule');
+        my $total = 0;
+        for ({ a => 1, b => 3 }) -> $key, $value {
+            $total = $total + $value;
+        }
+        return $total;
+        FORMULA
+    ok $f ~~ Agrammon::Formula, 'Get something doing Agrammon::Formula from parse';
+    is-deeply $f.input-used, (), 'Correct inputs-used';
+    is-deeply $f.technical-used, (), 'Correct technical-used';
+    is-deeply $f.output-used, (), 'Correct output-used';
+    my $result = compile-and-evaluate($f, Agrammon::Environment.new);
+    is $result, 4, 'Correct result from for loop over hash literal';
+}, 'For loop over hash literal';
+
+subtest {
+    my $f = parse-formula(q:to/FORMULA/, 'TestModule');
+        my $mapping = { x => 10, y => 20 };
+        my $total = 0;
+        for ($mapping) -> $key, $value {
+            $total = $total + $value;
+        }
+        return $total;
+        FORMULA
+    ok $f ~~ Agrammon::Formula, 'Get something doing Agrammon::Formula from parse';
+    is-deeply $f.input-used, (), 'Correct inputs-used';
+    is-deeply $f.technical-used, (), 'Correct technical-used';
+    is-deeply $f.output-used, (), 'Correct output-used';
+    my $result = compile-and-evaluate($f, Agrammon::Environment.new);
+    is $result, 30, 'Correct result from for loop over variable containing hash';
+}, 'For loop over variable containing hash';
+
+subtest {
+    my $f = parse-formula(q:to/FORMULA/, 'TestModule');
+        my $h = { apple => 2, banana => 3 };
+        my $keys = '';
+        my $total = 0;
+        for ($h) -> $key, $value {
+            $keys = $keys . $key . ',';
+            $total = $total + $value;
+        }
+        return $keys . $total;
+        FORMULA
+    ok $f ~~ Agrammon::Formula, 'Get something doing Agrammon::Formula from parse';
+    is-deeply $f.input-used, (), 'Correct inputs-used';
+    is-deeply $f.technical-used, (), 'Correct technical-used';
+    is-deeply $f.output-used, (), 'Correct output-used';
+    my $result = compile-and-evaluate($f, Agrammon::Environment.new);
+    ok $result eq 'apple,banana,5' || $result eq 'banana,apple,5',
+        'Correct result with keys concatenated (either order)';
+}, 'For loop over hash verifying keys';
+
+subtest {
+    my $f = parse-formula(q:to/FORMULA/, 'TestModule');
+        my $res = 0;
+        for (['bc', 'th', 'ts']) -> $tech {
+            $res = $res + $TE->{'app_tech_' . $tech};
+        }
+        return $res;
+        FORMULA
+    ok $f ~~ Agrammon::Formula, 'Get something doing Agrammon::Formula from parse';
+    is-deeply $f.input-used, (), 'Correct inputs-used';
+    is-deeply $f.technical-used, (), 'Correct technical-used (indirect not included)';
+    is-deeply $f.output-used, (), 'Correct output-used';
+    my $result = compile-and-evaluate($f, Agrammon::Environment.new(
+        technical => { app_tech_bc => 10, app_tech_th => 20, app_tech_ts => 30 }
+    ));
+    is $result, 60, 'Correct result from for loop with dynamic technical access';
+}, 'For loop with indirect technical access';
+
 done-testing;


### PR DESCRIPTION
For loops mostly use the Raku syntax (`->` style), however since our `if` and `given` all currently require parens around the condition or topic, we require them here too for consistency. We allow multiple loop variables for iterating two items at a time.

For hashes, we do a key/value iteration, so you iterate the two at once and put them into separate variables. This isn't quite Perl or Raku, but it is the path of least resistance from what we have today to getting something useful. (We also don't go down the path of sigils beyond the existing `$`.)

Finally, array literals like `[1, 2]` are also introduced. They can be used directly with `for` or assigned to a variable. There are no other operations on arrays for now; they are introduced primarily in support of `for`.

An example just like the request in https://github.com/oposs/agrammon/issues/600 is included among the tests, to make sure we can handle that use case.