### PR TITLE
Add persistent local podman DB for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ thirdparty/touch
 thirdparty/lib/
 thirdparty/work/
 thirdparty/bin/
+dev/db-data/

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,3 +70,61 @@ test:
 # Skip DB-backed tests (those that honor AGRAMMON_UNIT_TEST=1).
 unit-test:
 	AGRAMMON_UNIT_TEST=1 prove6 -l t/
+
+# --- Local development database (podman, persistent) --------------------------
+#
+# Reuses the test image (built via $(DB_IMAGE)) but runs a separate container
+# on a different port with a bind-mounted data directory so datasets survive
+# container restarts. Setting AGRAMMON_DEV_PASSWORD on first start gives the
+# seeded admin user (test@agrammon.ch) a working password for web UI login.
+#
+# Schema/seed scripts only run on the FIRST start (when DEV_DB_DATA is empty).
+# To pick up schema changes, run `make dev-db-reset`.
+
+DEV_DB_CONTAINER ?= agrammon-dev-db
+DEV_DB_PORT      ?= 55433
+DEV_DB_DATA      ?= $(abs_top_builddir)/dev/db-data
+DEV_DB_PASSWORD  ?= agrammon
+
+.PHONY: dev-db-start dev-db-stop dev-db-restart dev-db-logs dev-db-psql dev-db-reset
+
+dev-db-start: db-build
+	@mkdir -p $(DEV_DB_DATA)
+	$(PODMAN) run -d \
+	    -p $(DEV_DB_PORT):5432 \
+	    --name $(DEV_DB_CONTAINER) --replace \
+	    -e AGRAMMON_DEV_PASSWORD=$(DEV_DB_PASSWORD) \
+	    -v $(DEV_DB_DATA):/var/lib/postgresql/data:Z \
+	    $(DB_IMAGE)
+	@echo "Waiting for dev DB to accept connections..."
+	@for i in $$(seq 1 30); do \
+	    if $(PODMAN) exec $(DEV_DB_CONTAINER) pg_isready -U postgres -d agrammon_test >/dev/null 2>&1; then \
+	        echo "Dev DB ready on localhost:$(DEV_DB_PORT) (login: test@agrammon.ch / $(DEV_DB_PASSWORD))"; \
+	        exit 0; \
+	    fi; \
+	    sleep 1; \
+	done; \
+	echo "Dev DB did not become ready in 30s; recent container logs:"; \
+	$(PODMAN) logs --tail 50 $(DEV_DB_CONTAINER); \
+	exit 1
+
+dev-db-stop:
+	-$(PODMAN) stop $(DEV_DB_CONTAINER)
+	-$(PODMAN) rm $(DEV_DB_CONTAINER)
+
+dev-db-restart: dev-db-stop dev-db-start
+
+dev-db-logs:
+	$(PODMAN) logs $(DEV_DB_CONTAINER)
+
+dev-db-psql:
+	psql -h localhost -p $(DEV_DB_PORT) -U agrammon -d agrammon_test
+
+# Wipe the bind-mounted data directory so the next start re-runs init scripts.
+# Refuses to delete unless DEV_DB_DATA looks like a project-relative path, to
+# avoid wiping an unintended directory if someone overrides DEV_DB_DATA.
+dev-db-reset: dev-db-stop
+	@case "$(DEV_DB_DATA)" in \
+	    */dev/db-data) rm -rf $(DEV_DB_DATA); echo "Wiped $(DEV_DB_DATA)";; \
+	    *) echo "Refusing to wipe DEV_DB_DATA=$(DEV_DB_DATA): not a */dev/db-data path"; exit 1;; \
+	esac

--- a/dev/README-podman.md
+++ b/dev/README-podman.md
@@ -1,0 +1,76 @@
+# Local development with the podman PostgreSQL DB
+
+This setup gives you a persistent local PostgreSQL container (separate from
+the ephemeral test DB used by CI) plus a web-app launcher pointed at it.
+Datasets you create through the GUI survive container restarts.
+
+## One-time setup
+
+Build dependencies are the same as the existing test DB workflow (podman
+must be installed and `t/Dockerfile` must be buildable). The `init` scripts
+under `t/` ship the schema and a single seeded admin user
+(`test@agrammon.ch`).
+
+## Daily workflow
+
+```bash
+# Start the dev DB (builds the image on first run, idempotent thereafter)
+make dev-db-start
+
+# Run the web app
+./runWebDev.sh
+
+# In another terminal: open http://localhost:20000 and log in as
+#   test@agrammon.ch  /  agrammon
+```
+
+When you're done:
+
+```bash
+# Stops and removes the container; data persists in dev/db-data/
+make dev-db-stop
+```
+
+## Useful targets
+
+| Target              | What it does                                              |
+| ------------------- | --------------------------------------------------------- |
+| `dev-db-start`      | Build image (if needed) and start the container.          |
+| `dev-db-stop`       | Stop and remove the container. Data persists.             |
+| `dev-db-restart`    | Stop + start.                                             |
+| `dev-db-logs`       | Tail the container log.                                   |
+| `dev-db-psql`       | Open a psql shell as `agrammon`.                          |
+| `dev-db-reset`      | Stop the container and **wipe `dev/db-data/`**. Next start re-runs the schema/seed scripts. Use this after schema changes. |
+
+## How it differs from the test DB
+
+|                       | Test DB (`make db-start`)        | Dev DB (`make dev-db-start`)         |
+| --------------------- | -------------------------------- | ------------------------------------ |
+| Container name        | `agrammon-postgres`              | `agrammon-dev-db`                    |
+| Host port             | `55432`                          | `55433`                              |
+| Data directory        | container-internal (ephemeral)   | bind-mount `dev/db-data/` (persistent) |
+| Admin password        | placeholder, login won't work    | `agrammon` (override via `DEV_DB_PASSWORD=...`) |
+| Init scripts re-run?  | every fresh start                | only on first start (re-init via `dev-db-reset`) |
+
+The two can run side by side — different ports, different containers.
+
+## Variables
+
+```bash
+make dev-db-start \
+  DEV_DB_PORT=55444 \
+  DEV_DB_DATA=/some/other/path/dev/db-data \
+  DEV_DB_PASSWORD=mySecret
+```
+
+`DEV_DB_DATA` must end in `/dev/db-data` for `dev-db-reset` to delete it
+(safety check).
+
+## Notes
+
+- Schema/seed changes in `t/test-data/agrammon.schema.sql` or
+  `t/test-data/agrammon.test.sql` only affect a fresh DB. To pick them up,
+  run `make dev-db-reset` (this destroys your dev datasets).
+- The seeded admin user is the same row as the test seed; the dev-only
+  `t/04-dev-password.sh` init script overrides its password to a usable
+  value when `AGRAMMON_DEV_PASSWORD` is set in the container env.

--- a/dev/agrammon.dev.yaml
+++ b/dev/agrammon.dev.yaml
@@ -1,0 +1,36 @@
+General:
+    debugLevel: 0
+    log_file:   /tmp/agrammon-dev.log
+    log_level:  info
+    mojo_secret: dev-cookie-secret-change-me-if-you-care
+    tmpDir:     agrammon-dev
+    latexTimeout: 30
+    pdflatex:    /usr/bin/lualatex
+    translationDir: share/translations
+
+Database:
+    name:     agrammon_test
+    host:     localhost
+    port:     55433
+    user:     agrammon
+    password: agrammon
+    version: '6.0'
+    modelVersions: 5,6
+
+GUI:
+    baseUrl: http://localhost:20000
+    variant: Single
+    title:
+        de: AGRAMMON 6.6.0 Einzelbetriebsmodell (DEV)
+        en: AGRAMMON 6.6.0 Single Farm Model (DEV)
+        fr: AGRAMMON 6.6.0 modèle Exploitation individuelle (DEV)
+        it: AGRAMMON 6.6.0 modello di sfruttamento individuale (DEV)
+
+Model:
+    debugLevel: 0
+    path:      share/Models
+    model:     version6
+    technical: technical.cfg
+    top:       End.nhd
+    variant:   Base
+    version:   '6.6.0'

--- a/runWebDev.sh
+++ b/runWebDev.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+# Run the web app against the local podman dev database (see Makefile
+# `make dev-db-start`). The DB persists across container restarts via the
+# bind mount in dev/db-data/. Default login: test@agrammon.ch / agrammon.
+set -e
+
+cd "$(dirname "$0")"
+
+if ! podman container exists agrammon-dev-db 2>/dev/null; then
+    echo "Dev DB container not running. Start it first with: make dev-db-start" >&2
+    exit 1
+fi
+
+export PERL5LIB=Inline/perl5
+exec raku -Ilib bin/agrammon.raku --cfg-file=dev/agrammon.dev.yaml web version6/End.nhd

--- a/t/04-dev-password.sh
+++ b/t/04-dev-password.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Optional dev-only init step: set a usable password for the seeded admin
+# user (test@agrammon.ch) so a developer can actually log in via the web UI
+# against the local podman DB. Gated on AGRAMMON_DEV_PASSWORD: when unset
+# (the test-DB case) this script is a no-op, leaving the test seed alone.
+#
+# Runs after 03-agrammon.test.sql in /docker-entrypoint-initdb.d/ alphabetical
+# order, so the row to update already exists. Uses psql -v to safely quote
+# the password value.
+set -e
+
+if [ -z "$AGRAMMON_DEV_PASSWORD" ]; then
+    exit 0
+fi
+
+psql -v ON_ERROR_STOP=1 \
+     -v dev_pwd="$AGRAMMON_DEV_PASSWORD" \
+     --username "$POSTGRES_USER" \
+     --dbname "$POSTGRES_DB" <<-'EOSQL'
+    UPDATE pers
+       SET pers_password = crypt(:'dev_pwd', gen_salt('bf'))
+     WHERE pers_email = 'test@agrammon.ch';
+EOSQL
+
+echo "Dev password set for test@agrammon.ch"

--- a/t/Dockerfile
+++ b/t/Dockerfile
@@ -13,9 +13,14 @@ ENV POSTGRES_PASSWORD=postgres
 COPY init-roles.sh /docker-entrypoint-initdb.d/01-init-roles.sh
 COPY test-data/agrammon.schema.sql /docker-entrypoint-initdb.d/02-agrammon.schema.sql
 COPY test-data/agrammon.test.sql /docker-entrypoint-initdb.d/03-agrammon.test.sql
+# Optional dev-only password setup. No-op unless AGRAMMON_DEV_PASSWORD is
+# passed at container start; lets the same image serve test (CI) and dev
+# (local web UI login) workflows.
+COPY 04-dev-password.sh /docker-entrypoint-initdb.d/04-dev-password.sh
 
-# Make sure the init script is executable
-RUN chmod +x /docker-entrypoint-initdb.d/01-init-roles.sh
+# Make sure the init scripts are executable
+RUN chmod +x /docker-entrypoint-initdb.d/01-init-roles.sh \
+              /docker-entrypoint-initdb.d/04-dev-password.sh
 
 # Expose PostgreSQL port
 EXPOSE 5432


### PR DESCRIPTION
Lets a developer run the web app against a podman PostgreSQL container whose data survives restarts (bind-mounted to dev/db-data/), with a seeded admin login that actually works. Coexists with the existing ephemeral test DB — different container, different port.

Setup
- t/04-dev-password.sh: optional init-time script gated on AGRAMMON_DEV_PASSWORD. No-op for the test DB; sets a usable bcrypt password on the seeded `test@agrammon.ch` row when called from the dev DB target.
- t/Dockerfile: COPY the new init script (chmod +x).
- Makefile.am: dev-db-start/stop/restart/logs/psql/reset targets. Container `agrammon-dev-db` on port 55433, bind-mounts `$(abs_top_builddir)/dev/db-data` (Z relabel for SELinux), passes AGRAMMON_DEV_PASSWORD=agrammon by default. dev-db-reset has a safety check refusing to wipe paths not ending in `/dev/db-data`.
- dev/agrammon.dev.yaml: single-farm config pointed at port 55433.
- runWebDev.sh: launches the web app against that config; refuses to run if the dev container isn't up.
- dev/README-podman.md: workflow docs (start, login, schema-change reset cycle, side-by-side test vs dev table).
- .gitignore: dev/db-data/.

Smoke tested: container starts, `test@agrammon.ch` / `agrammon` login verified via crypt() round-trip, marker row survives stop+start cycle, dev-db-reset safety check rejects bogus DEV_DB_DATA paths. Test DB (`agrammon-postgres` on 55432) and dev DB (`agrammon-dev-db` on 55433) run side by side without conflict.