### PR TITLE
Slurry seasonal/tech share formulas: zero-sum guard and sum-to-100 warning

### DIFF
--- a/share/Models/version6/Application/Slurry/Cseason.nhd
+++ b/share/Models/version6/Application/Slurry/Cseason.nhd
@@ -96,12 +96,19 @@ is applied.
 
 +appl_season_sum
   print = 22
-  ++units 
+  ++units
     en = -
   ++description
     .
   ++formula
-    In(appl_summer) + In(appl_autumn_winter_spring);
+    my $season_sum = In(appl_summer) + In(appl_autumn_winter_spring);
+    if( abs( $season_sum - 100)  > 1e-6 )
+    {
+	writeLog({en => "Please correct accordingly: the categories 'share of slurry applied June to August' and 'share of slurry applied September to May' must add up to 100 \%!\n",
+		  de => "Bitte korrigieren: Die Summe der Kategorien Ausbringung von Gülle im Sommer (Juni, Juli, August) und Ausbringung von Gülle von September bis und mit Mai muss 100\% geben!\n",
+		  fr => "Veuillez corriger: la somme des catégories‚ «Part de lisier épandu en été (de juin à août)» et «Part de lisier épandu de septembre à mai y c.» doit donner 100%!\n"});
+    }
+    return $season_sum;
 
 +appl_summer
   print = 22

--- a/share/Models/version6/Application/Slurry/Cseason.nhd
+++ b/share/Models/version6/Application/Slurry/Cseason.nhd
@@ -114,12 +114,12 @@ is applied.
     0.5;
 ?else
   ++formula
-    In(appl_summer) / Out(appl_season_sum);
+    Out(appl_season_sum) > 0 ? In(appl_summer) / Out(appl_season_sum) : 0;
 ?endif
 
 +appl_autumn_winter_spring
   print = 22
-  ++units 
+  ++units
     en = -
   ++description
     .
@@ -128,6 +128,6 @@ is applied.
     0.5;
 ?else
   ++formula
-    In(appl_autumn_winter_spring) / Out(appl_season_sum);
+    Out(appl_season_sum) > 0 ? In(appl_autumn_winter_spring) / Out(appl_season_sum) : 0;
 ?endif
 

--- a/share/Models/version6/Application/Slurry/Ctech.nhd
+++ b/share/Models/version6/Application/Slurry/Ctech.nhd
@@ -199,46 +199,46 @@ taxonomy = Application::Slurry::Ctech
 
 +share_deep_injection
   print = 22
-  ++units 
+  ++units
     en = -
   ++description
     Share
   ++formula
-    In(share_deep_injection) / Out(share_apptech_sum);
+    Out(share_apptech_sum) > 0 ? In(share_deep_injection) / Out(share_apptech_sum) : 0;
 
 +share_shallow_injection
   print = 22
-  ++units 
+  ++units
     en = -
   ++description
     Share
   ++formula
-    In(share_shallow_injection) / Out(share_apptech_sum);
+    Out(share_apptech_sum) > 0 ? In(share_shallow_injection) / Out(share_apptech_sum) : 0;
 
 +share_trailing_shoe
  print = 22
-  ++units 
+  ++units
     en = -
   ++description
     Share
   ++formula
-    In(share_trailing_shoe) / Out(share_apptech_sum);
+    Out(share_apptech_sum) > 0 ? In(share_trailing_shoe) / Out(share_apptech_sum) : 0;
 
 +share_trailing_hose
  print = 22
-  ++units 
+  ++units
     en = -
   ++description
     Share
   ++formula
-    In(share_trailing_hose) / Out(share_apptech_sum);
+    Out(share_apptech_sum) > 0 ? In(share_trailing_hose) / Out(share_apptech_sum) : 0;
 
 +share_splash_plate
  print = 22
-  ++units 
+  ++units
     en = -
   ++description
     Share
   ++formula
-    In(share_splash_plate) / Out(share_apptech_sum);
+    Out(share_apptech_sum) > 0 ? In(share_splash_plate) / Out(share_apptech_sum) : 0;
 


### PR DESCRIPTION
Two related fixes to the Application::Slurry share formulas, both about catching user-input mistakes early rather than producing nonsense downstream.

## 1. Guard against zero-sum input (`dd500c38`)

Each per-tech share output in `Application::Slurry::Ctech` (5 outputs) and each per-season share output in `Application::Slurry::Cseason` (2 outputs, non-Kantonal_LU branch) divided an input by the sum of its sibling inputs. When the user hadn't filled the inputs yet — typical for fresh datasets and integration-test fixtures — the sum was 0, division produced a 0/0 `Rat` that `Model.rakumod` stores as the literal string `'ERROR: division by 0'`, and any downstream formula reading that output (notably `Application::Slurry::Alfam2::er_alfam2*`) died trying to coerce that string to a number.

Add an explicit `Out(sum) > 0 ? In(x)/Out(sum) : 0` guard. Behavior unchanged when shares actually sum to a positive number; just stops the cascade when they don't. The existing soft `writeLog` warning in `share_apptech_sum` (when the sum isn't ~100) and the model's validation layer still flag the under-filled state.

`Application::SolidManure::Cseason` already divides by 100 directly, so it's not affected. Verified end-to-end against a dataset with all five Ctech share inputs and both Cseason season inputs at 0: calc previously crashed at `er_alfam2_share_bc`; now completes with ~97KB of output.

## 2. Sum-to-100 warning in Cseason (`c79ad1aa`)

`Application::Slurry::Ctech::share_apptech_sum` writes a per-locale warning to the log when the five technology shares don't add up to 100%. `Application::Slurry::Cseason::appl_season_sum` had no such check — bad summer/Sep-May splits silently produced wrong emission numbers. Mirror the Ctech check (capture the sum, `if abs(sum-100) > 1e-6 writeLog{...}`, return the sum), so users get a log warning instead of having to spot the bad math by looking at the outputs.

## Test plan

- [x] Manual: end-to-end calc with all share inputs at 0 (the case that originally crashed)
- [x] Manual: end-to-end calc with shares that don't sum to 100 — log now flags it
- [ ] Manual: end-to-end calc with shares that DO sum to 100 — no warning, numbers unchanged
- [ ] `make test` against the test DB
