### PR TITLE
Clean up model-version YAML schema, fix renderer, add compatibleVersions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+- Unreleased
+
+  - Clean up version-related YAML fields.
+    - `Database.version` is removed; `dataset.dataset_version` is now
+      sourced from `Model.version` (the same identifier the version
+      switcher matches against in `Versions[].version`). Frontend fade
+      now compares like-with-like.
+    - `Model.model` is removed (was never read by any code path).
+    - New optional `GUI.version` field for the short user-visible
+      version label (e.g. '7.0'). Exposed in `get_cfg` as `guiVersion`.
+      Falls through to `Model.version` when not set.
+    - `Versions[].label` is renamed to `Versions[].guiVersion`.
+  - **Migration required** if you have datasets from before this
+    change: see `db/migrate-dataset-version-source.sql`. Without
+    migration, legacy datasets can be listed but not modified by the
+    running deployment, because the `(user, name, variant)` lookup
+    in store-variable won't find them.
+  - Fix DatasetVersion row renderer: themed font (was browser default),
+    accessible mismatch color (was opacity-based, failed WCAG AA).
+
 - 6.6.1, 2026-03-05, fritz.zaucker@oetiker.ch
 
   - Add bulk account creation via CSV file upload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@
     migration, legacy datasets can be listed but not modified by the
     running deployment, because the `(user, name, variant)` lookup
     in store-variable won't find them.
+  - New optional `Model.compatibleVersions` list — Model.version
+    strings whose datasets this deployment will claim (promote to its
+    own Model.version) on first open. Lets two sibling deployments
+    share datasets without a manual migration step: opening a foreign-
+    version dataset in the other deployment silently rewrites its
+    `dataset_version`, making subsequent edits work normally. Set
+    on both sides for round-trip editing. Empty/omitted = strict mode
+    (only own version).
   - Fix DatasetVersion row renderer: themed font (was browser default),
     accessible mismatch color (was opacity-based, failed WCAG AA).
 

--- a/db/migrate-dataset-version-source.sql
+++ b/db/migrate-dataset-version-source.sql
@@ -1,0 +1,37 @@
+-- Migration for the schema change: dataset_version is now sourced from
+-- Model.version (the running deployment's internal model identifier),
+-- previously from Database.version (the YAML field that was dropped).
+--
+-- Existing rows were written with the OLD Database.version values
+-- (typically '6.0', '7.0', sometimes per-major shorthand). After the
+-- change, the running deployment looks for datasets tagged with its
+-- Model.version ('6.6.0', '7.0.0', '6.5.2', ...) and won't find legacy
+-- rows — UPDATE / LOAD / DELETE silently fail (NULL dataset_id) until
+-- the rows are promoted.
+--
+-- Run ONCE per deployment, mapping each historical dataset_version
+-- value to the Model.version of the deployment that should own it.
+-- Adjust the WHEN clauses to match your production history.
+--
+-- Always: take a pg_dump backup before running.
+--
+-- Example for the canonical Agrammon 6.x → 6.6.0 / 7.x → 7.0.0
+-- deployment pattern; edit the version strings to fit your situation.
+
+BEGIN;
+
+UPDATE dataset SET dataset_version = CASE dataset_version
+    WHEN '6.0'  THEN '6.6.0'
+    WHEN '7.0'  THEN '7.0.0'
+    ELSE dataset_version            -- leave anything else alone
+END
+WHERE dataset_version IN ('6.0', '7.0');
+
+-- Sanity check before committing — review what's about to change.
+-- COMMIT only if the row counts look right:
+SELECT dataset_version, COUNT(*) AS row_count
+  FROM dataset
+ GROUP BY dataset_version
+ ORDER BY dataset_version;
+
+COMMIT;

--- a/etc/agrammon.yaml.dist
+++ b/etc/agrammon.yaml.dist
@@ -28,26 +28,27 @@ Model:
     version:   "6.0 - #REV#"
 
 # Sibling model versions reachable from this deployment.
-# Each entry: { label, url, version, title }
-#   - label    short string shown in the dropdown
-#   - url      where to navigate when this version is picked
-#   - version  matches the Model.version of the sibling instance;
-#              the entry whose version equals THIS process's
-#              Model.version is the active one. Switching to a strictly
-#              older version triggers a confirm dialog in the GUI.
-#   - title    per-locale title shown in the GUI header for THIS version.
-#              The active entry's title overrides GUI.title.
+# Each entry: { guiVersion, url, version, title }
+#   - guiVersion  short user-facing label shown in the dropdown
+#                 (matches the sibling's GUI.version)
+#   - url         where to navigate when this version is picked
+#   - version     matches the Model.version of the sibling instance;
+#                 the entry whose version equals THIS process's
+#                 Model.version is the active one. Switching to a strictly
+#                 older version triggers a confirm dialog in the GUI.
+#   - title       per-locale title shown in the GUI header for THIS version.
+#                 The active entry's title overrides GUI.title.
 # Order should be newest first.
 # Leave the block out (or empty) to hide the dropdown.
 Versions:
-    - label:   '7.0'
+    - guiVersion:   '7.0'
       url:     /single/v7
       version: '7.0.0'
       title:
           de: AGRAMMON 7.0 Einzelbetriebsmodell
           en: AGRAMMON 7.0 Single Farm Model
           fr: AGRAMMON 7.0 modèle Exploitation individuelle
-    - label:   '6.6'
+    - guiVersion:   '6.6'
       url:     /single/v6
       version: '6.6.0'
       title:

--- a/etc/agrammon.yaml.dist
+++ b/etc/agrammon.yaml.dist
@@ -26,6 +26,13 @@ Model:
     technical: technical.cfg
     variant:   SHL
     version:   "6.0 - #REV#"
+    # Other Model.version strings whose datasets this deployment will
+    # claim (promote to this Model.version) on first open. Use sparingly
+    # — promotion is one-way per dataset. Leave empty (or omit) for
+    # strict mode.
+    # compatibleVersions:
+    #     - '6.5.2'
+    #     - '6.6.0'
 
 # Sibling model versions reachable from this deployment.
 # Each entry: { guiVersion, url, version, title }

--- a/frontend/source/class/agrammon/ui/menu/OptionMenu.js
+++ b/frontend/source/class/agrammon/ui/menu/OptionMenu.js
@@ -188,7 +188,7 @@ qx.Class.define('agrammon.ui.menu.OptionMenu', {
 
             for (var i = 0; i < versions.length; i++) {
                 var v = versions[i];
-                var btn = new qx.ui.menu.Button(v.label);
+                var btn = new qx.ui.menu.Button(v.guiVersion);
                 btn.setUserData('versionEntry', v);
                 if (v.version === activeVersion) {
                     // Can't switch to ourselves — make it visually obvious

--- a/frontend/source/class/agrammon/ui/table/rowrenderer/DatasetVersion.js
+++ b/frontend/source/class/agrammon/ui/table/rowrenderer/DatasetVersion.js
@@ -16,15 +16,26 @@ qx.Class.define('agrammon.ui.table.rowrenderer.DatasetVersion', {
         this.base(arguments);
         this.__versionColumn = versionColumn;
 
-        this.__fontStyle = qx.bom.Font.getDefaultStyles();
+        // Resolve the THEME's default font so cells render in the same
+        // typeface as the rest of the app. qx.bom.Font.getDefaultStyles()
+        // returns the BROWSER default (serif) which shows up as Times New
+        // Roman.
+        var font = qx.theme.manager.Font.getInstance().resolve("default");
+        this.__fontStyle = font ? font.getStyles()
+                                : qx.bom.Font.getDefaultStyles();
         this.__fontStyleString = qx.bom.element.Style.compile(this.__fontStyle).replace(/"/g, "'");
 
         var colorMgr = qx.theme.manager.Color.getInstance();
+        // Mismatch rows use a muted color rather than opacity: opacity
+        // stacking drops effective contrast below WCAG AA (DevTools
+        // flags it), but a real gray that still meets 4.5:1 on the row
+        // background passes the contrast check. #555 = ~7.5:1 on white.
         this._colors = {
             bgcolFocused: colorMgr.resolve("table-row-background-focused"),
             bgcolEven:    colorMgr.resolve("table-row-background-even"),
             bgcolOdd:     colorMgr.resolve("table-row-background-odd"),
             colNormal:    colorMgr.resolve("table-row"),
+            colMismatch:  "#555",
             horLine:      colorMgr.resolve("table-row-line")
         };
     },
@@ -62,9 +73,12 @@ qx.Class.define('agrammon.ui.table.rowrenderer.DatasetVersion', {
                     : this._colors.bgcolOdd;
             }
 
-            style.color = this._colors.colNormal;
+            style.color = this.__isMismatch(rowInfo.rowData)
+                ? this._colors.colMismatch
+                : this._colors.colNormal;
             style.borderBottom = "1px solid " + this._colors.horLine;
-            style.opacity = this.__isMismatch(rowInfo.rowData) ? "0.45" : "1";
+            style.fontStyle = this.__isMismatch(rowInfo.rowData) ? "italic" : "normal";
+            style.opacity = "1";
         },
 
         getRowHeightStyle: function(height) {
@@ -84,10 +98,12 @@ qx.Class.define('agrammon.ui.table.rowrenderer.DatasetVersion', {
                 rowStyle.push((rowInfo.row % 2 == 0) ? this._colors.bgcolEven
                                                     : this._colors.bgcolOdd);
             }
-            rowStyle.push(';color:', this._colors.colNormal);
+            var mismatch = this.__isMismatch(rowInfo.rowData);
+            rowStyle.push(';color:', mismatch ? this._colors.colMismatch
+                                              : this._colors.colNormal);
             rowStyle.push(';border-bottom: 1px solid ', this._colors.horLine);
-            if (this.__isMismatch(rowInfo.rowData)) {
-                rowStyle.push(';opacity:0.45');
+            if (mismatch) {
+                rowStyle.push(';font-style:italic');
             }
             return rowStyle.join("");
         },

--- a/lib/Agrammon/Config.rakumod
+++ b/lib/Agrammon/Config.rakumod
@@ -53,8 +53,13 @@ class Agrammon::Config {
     }
 
     method agrammon-variant {
+        # `version` tags rows written to `dataset.dataset_version`. Sourced
+        # from Model.version (the same identifier the frontend compares
+        # against in the version switcher), so that dataset table rows
+        # written by this deployment are recognized as belonging to it.
+        # Was Database.version historically — see CHANGELOG.
         %(
-            version => %!database<version>,
+            version => %!model<version>,
             gui     => %!gui<variant>,
             model   => %!model<variant>,
         );

--- a/lib/Agrammon/Config.rakumod
+++ b/lib/Agrammon/Config.rakumod
@@ -40,6 +40,13 @@ class Agrammon::Config {
         %!gui<title>;
     }
 
+    # User-visible short version label (e.g. '7.0'). Distinct from
+    # Model.version (internal identifier). Optional; falls through to
+    # Model.version when not set so existing deployments keep working.
+    method gui-version {
+        %!gui<version> // %!model<version>;
+    }
+
     method model-variant {
         %!model<variant>;
     }

--- a/lib/Agrammon/Config.rakumod
+++ b/lib/Agrammon/Config.rakumod
@@ -59,6 +59,14 @@ class Agrammon::Config {
         %!model<version>;
     }
 
+    # Other Model.version strings this deployment accepts as data-
+    # compatible: datasets tagged with any of these will be claimed
+    # (promoted to Model.version) on first open. Empty list = strict
+    # mode (only the deployment's own dataset rows are openable).
+    method model-compatible-versions {
+        (%!model<compatibleVersions> // ()).list;
+    }
+
     method agrammon-variant {
         # `version` tags rows written to `dataset.dataset_version`. Sourced
         # from Model.version (the same identifier the frontend compares
@@ -66,9 +74,10 @@ class Agrammon::Config {
         # written by this deployment are recognized as belonging to it.
         # Was Database.version historically — see CHANGELOG.
         %(
-            version => %!model<version>,
-            gui     => %!gui<variant>,
-            model   => %!model<variant>,
+            version             => %!model<version>,
+            gui                 => %!gui<variant>,
+            model               => %!model<variant>,
+            compatible-versions => self.model-compatible-versions,
         );
     }
 

--- a/lib/Agrammon/DB/Dataset.rakumod
+++ b/lib/Agrammon/DB/Dataset.rakumod
@@ -341,7 +341,31 @@ class Agrammon::DB::Dataset does Agrammon::DB::Variant {
         }
     }
 
+    # Promote a `(user, name, guivariant, modelvariant)` row whose
+    # dataset_version is in compatibleVersions (but not the current
+    # Model.version) to the current Model.version. After this UPDATE,
+    # the existing strict-version queries find the row normally.
+    # No-op if no row matches, or if compatibleVersions is empty.
+    method !ensure-version-match {
+        my @compat = self!compatible-versions;
+        return unless @compat;
+        my (Str $version, Str $gui, Str $model) = self!variant;
+        self.with-db: -> $db {
+            $db.query(q:to/SQL/, $version, $!user.username, $!name, $gui, $model, @compat);
+                UPDATE dataset
+                   SET dataset_version = $1
+                 WHERE dataset_pers         = pers_email2id($2)
+                   AND dataset_name         = $3
+                   AND dataset_guivariant   = $4
+                   AND dataset_modelvariant = $5
+                   AND dataset_version      = ANY($6)
+                   AND dataset_version     != $1
+            SQL
+        }
+    }
+
     method load {
+        self!ensure-version-match;
         self.with-db: -> $db {
             my $username = $!user.username;
             my $results = $db.query(q:to/DATASET/, $username, $!name,  |self!variant);

--- a/lib/Agrammon/DB/Variant.rakumod
+++ b/lib/Agrammon/DB/Variant.rakumod
@@ -9,5 +9,11 @@ role Agrammon::DB::Variant does Agrammon::DB {
     method !variant {
         return %!agrammon-variant<version gui model>;
     }
-    
+
+    # List of dataset_version values this deployment accepts in addition
+    # to its own. Used by Dataset.ensure-version-match to claim rows
+    # tagged with a compatible (older) Model.version on first open.
+    method !compatible-versions {
+        (%!agrammon-variant<compatible-versions> // ()).list;
+    }
 }

--- a/lib/Agrammon/Web/Service.rakumod
+++ b/lib/Agrammon/Web/Service.rakumod
@@ -44,6 +44,7 @@ class Agrammon::Web::Service {
             title        => %gui<title>,
             variant      => %model<variant>,
             version      => %model<version>,
+            guiVersion   => $!cfg.gui-version,
             submission   => %gui<submission>,
             baseUrl      => %gui<baseUrl>,
             versions     => $!cfg.versions,

--- a/t/config.rakutest
+++ b/t/config.rakutest
@@ -19,7 +19,6 @@ my %config-expected = (
         host     => 'localhost',
         user     => 'agrammon',
         password => "agrammon",
-        version  => '6.0',
     },
     GUI => {
         baseUrl => 'https://model.agrammon.ch/single/test',
@@ -33,7 +32,6 @@ my %config-expected = (
     Model => {
         debugLevel => 0,
         path       => 'share/Models',
-        model      => 'version6',
         top        =>  'End.nhd',
         technical  =>  'technical.cfg',
         variant    => 'Base',

--- a/t/config.rakutest
+++ b/t/config.rakutest
@@ -69,13 +69,13 @@ subtest "Versions block parsed" => {
     is $vcfg.versions.elems, 2, 'Two Versions entries';
 
     my $entry = $vcfg.versions[0];
-    is $entry<label>,        '7.0',                            'first entry label';
+    is $entry<guiVersion>,   '7.0',                            'first entry guiVersion';
     is $entry<url>,          '/single/v7',                     'first entry url';
     is $entry<version>,      '7.0.0',                          'first entry version';
     is $entry<title><en>,    'AGRAMMON 7.0 Single Farm Model', 'first entry English title';
 
-    is $vcfg.versions[1]<label>,   '6.0',        'second entry label';
-    is $vcfg.versions[1]<version>, '6.0',        'second entry version';
+    is $vcfg.versions[1]<guiVersion>, '6.0',     'second entry guiVersion';
+    is $vcfg.versions[1]<version>,    '6.0',     'second entry version';
 }
 
 done-testing;

--- a/t/test-data/agrammon.cfg-with-versions.yaml
+++ b/t/test-data/agrammon.cfg-with-versions.yaml
@@ -12,7 +12,6 @@ Database:
     port:     55432
     user:     agrammon
     password: agrammon
-    version: '6.0'
 
 GUI:
     baseUrl: https://model.agrammon.ch/single/test
@@ -25,7 +24,6 @@ GUI:
 Model:
     debugLevel: 0
     path:      share/Models
-    model:     version6
     top:       End.nhd
     technical: technical.cfg
     variant:   Base

--- a/t/test-data/agrammon.cfg-with-versions.yaml
+++ b/t/test-data/agrammon.cfg-with-versions.yaml
@@ -30,14 +30,14 @@ Model:
     version:   '6.0'
 
 Versions:
-    - label:   '7.0'
+    - guiVersion:   '7.0'
       url:     /single/v7
       version: '7.0.0'
       title:
           de: AGRAMMON 7.0 Einzelbetriebsmodell
           en: AGRAMMON 7.0 Single Farm Model
           fr: AGRAMMON 7.0 modèle Exploitation individuelle
-    - label:   '6.0'
+    - guiVersion:   '6.0'
       url:     /single/v6
       version: '6.0'
       title:

--- a/t/test-data/agrammon.cfg.yaml
+++ b/t/test-data/agrammon.cfg.yaml
@@ -12,7 +12,6 @@ Database:
     port:     55432
     user:     agrammon
     password: agrammon
-    version: '6.0'
 
 GUI:
     baseUrl: https://model.agrammon.ch/single/test
@@ -25,7 +24,6 @@ GUI:
 Model:
     debugLevel: 0
     path:      share/Models
-    model:     version6
     top:       End.nhd
     technical: technical.cfg
     variant:   Base

--- a/t/webservice.rakutest
+++ b/t/webservice.rakutest
@@ -89,6 +89,7 @@ transactionally {
                     },
             variant => "Base",
             version => "6.0",
+            guiVersion => "6.0",
             versions => [],
         );
         is-deeply $cfg = $ws.get-cfg, %cfg-expected, "Config as expected";


### PR DESCRIPTION
## Summary

Cleans up the version-related YAML schema and adds the missing piece that lets two sibling deployments share datasets across the version switcher (PR #629).

**Schema cleanup** — two redundant fields removed, one added:

| Field | Status | Why |
|---|---|---|
| `Database.version` | **removed** | Tagged `dataset.dataset_version` but unrelated to anything else — the frontend was comparing against `Model.version`, so the version-switcher fade never matched its own writes |
| `Model.model` | **removed** | Never read by any code path; the model directory is selected by the positional arg to `bin/agrammon.raku` |
| `GUI.version` | **added** (optional) | Short user-visible version label (e.g. `'7.0'`); exposed in `get_cfg` as `guiVersion`. Falls through to `Model.version` when not set so existing YAMLs keep working |
| `Versions[].label` | **renamed** → `guiVersion` | Always was the sibling's user-visible version, not a free-form label |
| `Model.compatibleVersions` | **added** (optional) | List of foreign `Model.version` strings whose datasets this deployment will claim on first open. See below |

**`dataset.dataset_version` now sourced from `Model.version`.** Frontend fade in the dataset table now compares like-with-like.

**`Model.compatibleVersions` for cross-version editing.** Without this, a dataset tagged `'6.5.2'` is unmodifiable from a v7 deployment (the `(user, name, variant)` lookup in `store-variable` fails). With it, `Dataset.load` runs a one-shot UPDATE that promotes the row's `dataset_version` to the current deployment's `Model.version` on first open, after which the existing strict lookup finds the row. Set on both sides for round-trip editing across two sibling deployments.

**Renderer bug fixes.** The dataset-table row renderer added in #629 used `qx.bom.Font.getDefaultStyles()` (browser default → Times New Roman) instead of the qx theme font, and faded mismatched rows with `opacity:0.45` which DevTools flagged as failing WCAG AA contrast. Now uses the themed font and an accessible muted color (`#555`, ~7.5:1 on white) plus italic.

## Migration

**Required if you have datasets from before this change.** Their `dataset_version` was set from the old `Database.version`. After the upgrade, the running deployment looks for rows tagged with its `Model.version` and won't find legacy rows — listing keeps working but writes silently fail (NULL `data_dataset`).

`db/migrate-dataset-version-source.sql` ships an `UPDATE` template. Run once per deployment after taking a `pg_dump` backup; edit the version mapping (e.g. `'6.0' → '6.6.0'`) to fit your deployment's history.

Alternatively, set `Model.version` in YAML to the legacy short value (`'6.0'`) — no DB change required, but you lose the granular identifier and the original namespace conflation comes back.

## Test plan

- [x] `prove6 -l t/config.rakutest` — passes (covers `Versions[].guiVersion` field rename in the existing positive test)
- [ ] `make test` — full suite against test DB
- [ ] Manual: configure two sibling deployments, each listing the other in `Model.compatibleVersions`; create a dataset on deployment A, switch to B via the version switcher, open the dataset, verify it loads + edits work; switch back to A and verify it now appears faded (B claimed it)
- [ ] Manual: confirm DevTools no longer reports contrast warnings on the dataset table rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
