### PR TITLE
spike: multi-stage container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,8 +8,10 @@ t/
 test/
 frontend/node_modules
 frontend/cache
-frontend/compiled/source
-frontend/compiled/build
+# Exclude the whole `compiled` entry — on the dev host this is a symlink
+# to /scratch/... and Docker copies the dangling link into the context,
+# breaking mkdir -p in the frontend builder stage.
+frontend/compiled
 frontend/.qx-builds
 *.bak
 *.tar.gz

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Speed up build context — exclude things the spike doesn't need.
+.git
+.planning
+.claude
+TODO
+Support
+t/
+test/
+frontend/node_modules
+frontend/cache
+frontend/compiled/source
+frontend/compiled/build
+frontend/.qx-builds
+*.bak
+*.tar.gz
+runWeb*.sh
+runSingle*.sh
+runRegional*.sh
+runKantonal*.sh
+runExcelTest.sh
+runFrontendTests.sh
+Dockerfile.spike
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,44 @@
 #   --build-arg RAKUDO_VERSION=2026.04-01
 #   --build-arg TYPST_VERSION=0.14.2
 
+# ─────────────────────────── Stage 0: fe-builder ────────────────────────
+# Compiles the Qooxdoo frontend (target=build) into /work/frontend/compiled/build,
+# which the runtime stage copies to /app/public. Independent of the Raku
+# builder below; the two run in parallel.
+FROM node:20-bookworm-slim AS fe-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Activate the pnpm version that frontend/package.json pins.
+RUN corepack enable && corepack prepare pnpm@10.4.1 --activate
+
+WORKDIR /work/frontend
+
+# Manifest + lockfile first → dependency layer caches across source edits.
+COPY frontend/package.json frontend/pnpm-lock.yaml /work/frontend/
+RUN pnpm install --frozen-lockfile
+
+# Now the rest of the frontend tree (sources, compile.json, qx_packages
+# manifest, translations, resources).
+COPY frontend/ /work/frontend/
+
+# qx compile does a plain `mkdir` (not -p) for the output, so the parent
+# directory must exist; the .dockerignore strips compiled/{source,build}
+# but doesn't recreate compiled/ itself if the local checkout had it
+# populated.  Just create it.
+RUN mkdir -p /work/frontend/compiled
+
+# Production build into compiled/build/. --feedback=false silences the
+# progress UI; --update-po-files keeps translation timestamps in sync so
+# the layer is reproducible.
+RUN pnpm exec qx compile --target=build --feedback=false --update-po-files
+
+# Reality check — index.html must end up at the root of compiled/build
+# for the Cro route `static "$root/index.html"` (lib/Agrammon/Web/Routes.rakumod
+# build-mode branch) to find it.
+RUN test -f /work/frontend/compiled/build/index.html
+
+
 # ─────────────────────────── Stage 1: builder ───────────────────────────
 FROM debian:bookworm-slim AS builder
 
@@ -111,8 +149,6 @@ RUN git clone --depth 1 https://github.com/croservices/cro-openapi-routes-from-d
 COPY lib/    /app/lib/
 COPY bin/    /app/bin/
 COPY share/  /app/share/
-# public/ is empty in this image; the multi-stage frontend builder is a
-# separate concern (see customers/oep/services/agrammon/OPEN-DECISIONS.md §1d).
 RUN mkdir -p /app/public
 
 # Build-time smoke — catches Raku compile errors inside lib/ before runtime.
@@ -159,8 +195,13 @@ COPY --from=builder /opt/perl5 /opt/perl5
 # typst binary.
 COPY --from=builder /usr/local/bin/typst /usr/local/bin/typst
 
-# App tree.
+# App tree (Raku source, share/, empty public/).
 COPY --from=builder /app /app
+
+# Qooxdoo build output. Routes.rakumod's build-mode branch serves
+# /index.html, /agrammon/*, /resource/* directly out of /app/public.
+COPY --from=fe-builder /work/frontend/compiled/build /app/public
+
 WORKDIR /app
 
 ENV PERL5LIB=/opt/perl5/lib/perl5:/app/Inline/perl5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,171 @@
+# syntax=docker/dockerfile:1.6
+#
+# Multi-stage build for Agrammon.
+#
+# Stage 1 (builder): debian:bookworm-slim + all *-dev headers, build-essential,
+# cpanminus, git. Installs Rakudo 2026.04 (rakudo.org prebuild), zef, all Raku
+# deps, Excel::Writer::XLSX via cpanm into a private --local-lib at /opt/perl5,
+# patches Cro::OpenAPI::RoutesFromDefinition with upstream PR #15 (not yet
+# merged), and runs a compile-check against lib/Agrammon/Model.rakumod.
+#
+# Stage 2 (runtime): debian:bookworm-slim + runtime libs only (libperl, libxml2,
+# libarchive13, libuuid1, libssl3, libpq5, Perl XML/IO/Archive deps,
+# ghostscript, fonts-liberation, ca-certificates). Copies /opt/rakudo, the
+# zef-installed site repo state under /root/.raku, /opt/perl5, /usr/local/bin/typst,
+# and the /app tree from the builder.
+#
+# Build-arg pins are fixed but overridable for one-off bumps:
+#   --build-arg RAKUDO_VERSION=2026.04-01
+#   --build-arg TYPST_VERSION=0.14.2
+
+# ─────────────────────────── Stage 1: builder ───────────────────────────
+FROM debian:bookworm-slim AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+#   - libperl-dev, cpanminus, build-essential, pkg-config →
+#       Inline::Perl5 + Excel::Writer::XLSX + native Raku module compile
+#   - libxml2-dev libarchive-dev uuid-dev libssl-dev libpq-dev →
+#       C headers for Raku native modules (LibXML, Libarchive, LibUUID,
+#       OpenSSL, DB::Pg)
+#   - ca-certificates, curl, xz-utils, git → fetch Rakudo + typst tarballs
+#                                            + clone zef + patch Cro::OpenAPI
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        perl libperl-dev cpanminus \
+        libxml2-dev libarchive-dev uuid-dev libssl-dev libpq-dev \
+        build-essential pkg-config \
+        ca-certificates curl xz-utils git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rakudo from rakudo.org prebuilt tarball — bone-stock (no zef, no deps).
+# Matches the host's working build (2026.04). The rakudo-star image (2026.03)
+# crashes formula EVAL with "duplicate definition of symbol Died" so we pin.
+ARG RAKUDO_VERSION=2026.04-01
+RUN curl -fsSL "https://rakudo.org/dl/rakudo/rakudo-moar-${RAKUDO_VERSION}-linux-x86_64-gcc.tar.gz" \
+        -o /tmp/rakudo.tar.gz \
+    && mkdir -p /opt/rakudo \
+    && tar -xzf /tmp/rakudo.tar.gz -C /opt/rakudo --strip-components=1 \
+    && rm /tmp/rakudo.tar.gz
+ENV PATH=/opt/rakudo/bin:/opt/rakudo/share/perl6/site/bin:/opt/rakudo/share/perl6/vendor/bin:/opt/rakudo/share/perl6/core/bin:$PATH
+
+# zef from upstream — not bundled with bare Rakudo.
+RUN git clone --depth 1 https://github.com/ugexe/zef /tmp/zef \
+    && cd /tmp/zef \
+    && raku -I. bin/zef install --/test . \
+    && cd / && rm -rf /tmp/zef \
+    && zef --version
+
+# typst — single ~30 MB static binary. Built in builder so the smoke step
+# can validate it, then COPY'd into the runtime stage.
+ARG TYPST_VERSION=0.14.2
+RUN curl -fsSL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz" \
+        -o /tmp/typst.tar.xz \
+    && tar -xJf /tmp/typst.tar.xz -C /tmp \
+    && install -m 0755 /tmp/typst-x86_64-unknown-linux-musl/typst /usr/local/bin/typst \
+    && rm -rf /tmp/typst.tar.xz /tmp/typst-x86_64-unknown-linux-musl \
+    && typst --version
+
+# Excel::Writer::XLSX — not a Debian package. Installed into a private
+# --local-lib so the runtime stage can COPY a single /opt/perl5 tree
+# instead of merging with the system Perl module path.
+RUN cpanm --local-lib /opt/perl5 --notest --quiet Excel::Writer::XLSX \
+    && rm -rf /root/.cpanm
+
+WORKDIR /app
+
+# Build context optimisation: META6.json first → unchanged when only source
+# files change → zef cache hit on rebuild.
+COPY META6.json /app/
+
+# Inline/perl5 must be in place before zef install (Inline::Perl5 looks at
+# PERL5LIB at compile time).
+COPY Inline/ /app/Inline/
+ENV PERL5LIB=/opt/perl5/lib/perl5:/app/Inline/perl5
+
+# Pin Text::CSV 0.015 — Spreadsheet::XLSX hard-pins it. Without the explicit
+# pre-install, zef also pulls 0.022 to satisfy the unpinned project dep;
+# having both installed is cosmetic only (single-version tree is cleaner).
+RUN zef install --/test 'Text::CSV:ver<0.015>:auth<zef:Tux>'
+
+# All other Raku deps from META6.json.
+RUN zef install --/test --deps-only . \
+    && rm -rf ~/.zef
+
+# Cro::OpenAPI::RoutesFromDefinition compatibility patch (upstream PR #15,
+# unmerged as of 2026-05). Without it, agrammon's `route { include … }`
+# block crashes at compile time with:
+#   No such method 'name' for invocant of type
+#   'Cro::OpenAPI::RoutesFromDefinition::OperationSet::OperationHandler'
+# This is a Cro::HTTP::Router 0.8.12+ regression that affects every
+# OpenAPI-based Cro app. Drop this RUN when the PR merges.
+# https://github.com/croservices/cro-openapi-routes-from-definition/pull/15
+RUN git clone --depth 1 https://github.com/croservices/cro-openapi-routes-from-definition /tmp/cro-openapi \
+    && cd /tmp/cro-openapi \
+    && curl -fsSL https://github.com/croservices/cro-openapi-routes-from-definition/pull/15.patch \
+        -o /tmp/pr15.patch \
+    && git apply --whitespace=nowarn /tmp/pr15.patch \
+    && zef install --/test --force-install . \
+    && cd / && rm -rf /tmp/cro-openapi /tmp/pr15.patch ~/.zef
+
+# App code — last so frequent edits don't bust the dep-install cache.
+COPY lib/    /app/lib/
+COPY bin/    /app/bin/
+COPY share/  /app/share/
+# public/ is empty in this image; the multi-stage frontend builder is a
+# separate concern (see customers/oep/services/agrammon/OPEN-DECISIONS.md §1d).
+RUN mkdir -p /app/public
+
+# Build-time smoke — catches Raku compile errors inside lib/ before runtime.
+RUN raku -Ilib -e 'use Agrammon::Model; say "compile OK"'
+
+# ────────────────────────── Stage 2: runtime ────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Runtime-only set — no compilers, no headers, no cpanm/git/curl/build tools.
+#   - perl + libperl5.36 → host Perl + libperl.so for Inline::Perl5
+#   - libxml-libxml-perl libio-stringy-perl libarchive-zip-perl →
+#       Excel::Writer::XLSX Perl-side runtime deps
+#   - libxml2 libarchive13 libuuid1 libssl3 libpq5 →
+#       shared libs the Raku native modules linked against in stage 1
+#   - ghostscript → optional typst PDF re-compression (General.ghostscript:)
+#   - fonts-liberation → "Liberation Sans" used by pdfexport.crotmp
+#   - ca-certificates → outbound TLS (e.g. to API consumers, future SMTP)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        perl libperl5.36 \
+        libxml-libxml-perl libio-stringy-perl libarchive-zip-perl \
+        libxml2 libarchive13 libuuid1 libssl3 libpq5 \
+        ghostscript fonts-liberation \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf libssl.so.3    /usr/lib/x86_64-linux-gnu/libssl.so \
+    && ln -sf libcrypto.so.3 /usr/lib/x86_64-linux-gnu/libcrypto.so
+# ^ Raku's IO::Socket::Async::SSL dlopens 'libssl.so' (unversioned). The
+#   libssl-dev package would supply both symlinks but pulls in compiler
+#   headers; libssl3 (runtime) does not. Cheaper to symlink directly.
+
+# Rakudo + zef-installed site repo (deps live under share/perl6/site/).
+COPY --from=builder /opt/rakudo /opt/rakudo
+ENV PATH=/opt/rakudo/bin:/opt/rakudo/share/perl6/site/bin:/opt/rakudo/share/perl6/vendor/bin:/opt/rakudo/share/perl6/core/bin:$PATH
+
+# zef may have left state under the home repo as well (precomp cache for
+# anything site-scope couldn't precompile at install time).
+COPY --from=builder /root/.raku /root/.raku
+
+# cpanm --local-lib output (Excel::Writer::XLSX + its Perl deps).
+COPY --from=builder /opt/perl5 /opt/perl5
+
+# typst binary.
+COPY --from=builder /usr/local/bin/typst /usr/local/bin/typst
+
+# App tree.
+COPY --from=builder /app /app
+WORKDIR /app
+
+ENV PERL5LIB=/opt/perl5/lib/perl5:/app/Inline/perl5
+ENV AGRAMMON_PORT=8080
+
+EXPOSE 8080
+ENTRYPOINT ["raku", "-Ilib", "/app/bin/agrammon.raku"]
+CMD ["--help"]

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,14 +66,26 @@ help:
 	@echo "  dev-db-psql       Open psql against the dev DB"
 	@echo "  dev-db-reset      Wipe dev DB data dir so init scripts re-run on next start"
 	@echo ""
-	@echo "Deployment:"
+	@echo "Deployment (tarball → web-volki-01):"
 	@echo "  deploy            Copy release tarball to deploy host and unpack"
+	@echo ""
+	@echo "Container image (multi-stage Dockerfile → $(CONTAINER_REGISTRY)):"
+	@echo "  image             Build the container image locally"
+	@echo "  image-push        Build and push to $(CONTAINER_REGISTRY) (login required)"
+	@echo "  image-test        Build + push with CONTAINER_ENV=test  (= $(CONTAINER_IMAGE):test-…)"
+	@echo "  image-prod        Build + push with CONTAINER_ENV=prod  (= $(CONTAINER_IMAGE):prod-…)"
+	@echo "  image-print       Show what \`image\` would build (resolves tag etc.)"
 	@echo ""
 	@echo "Variables (override on command line, e.g. make db-start DB_PORT=5555):"
 	@echo "  PODMAN=$(PODMAN)"
 	@echo "  DB_IMAGE=$(DB_IMAGE)  DB_CONTAINER=$(DB_CONTAINER)  DB_PORT=$(DB_PORT)"
 	@echo "  DEV_DB_CONTAINER=$(DEV_DB_CONTAINER)  DEV_DB_PORT=$(DEV_DB_PORT)"
 	@echo "  DEV_DB_DATA=$(DEV_DB_DATA)"
+	@echo "  CONTAINER_REGISTRY=$(CONTAINER_REGISTRY)"
+	@echo "  CONTAINER_PROJECT=$(CONTAINER_PROJECT)"
+	@echo "  CONTAINER_IMAGE=$(CONTAINER_IMAGE)"
+	@echo "  CONTAINER_ENV=$(CONTAINER_ENV)  CONTAINER_VERSION=$(CONTAINER_VERSION)"
+	@echo "  CONTAINER_TAG=$(CONTAINER_TAG)"
 
 deps:
 		zef --debug --/test --deps-only --test-depends install .
@@ -186,3 +198,50 @@ dev-db-reset: dev-db-stop
 	    */dev/db-data) rm -rf $(DEV_DB_DATA); echo "Wiped $(DEV_DB_DATA)";; \
 	    *) echo "Refusing to wipe DEV_DB_DATA=$(DEV_DB_DATA): not a */dev/db-data path"; exit 1;; \
 	esac
+
+# --- Container image (multi-stage Dockerfile → harbor.oetiker.ch) --------------
+#
+# Tag convention: <env>-<version>.  Customer overlay
+# (oep-k8s/customers/oep/services/agrammon/values.yaml) picks images.test.tag
+# or images.prod.tag depending on per-instance `env:`.
+#
+# Override on the command line, e.g.:
+#   make image-push CONTAINER_VERSION=2026.05.20 CONTAINER_ENV=prod
+#   make image      CONTAINER_BUILD_ARGS="--build-arg TYPST_VERSION=0.14.3"
+#
+# Login (one-time per session) before pushing:
+#   podman login harbor.oetiker.ch
+
+CONTAINER_REGISTRY ?= harbor.oetiker.ch
+CONTAINER_PROJECT  ?= oep
+CONTAINER_IMAGE    ?= $(CONTAINER_REGISTRY)/$(CONTAINER_PROJECT)/agrammon
+CONTAINER_VERSION  ?= $(shell cat VERSION 2>/dev/null || echo dev)
+CONTAINER_ENV      ?= test
+CONTAINER_TAG      ?= $(CONTAINER_ENV)-$(CONTAINER_VERSION)
+CONTAINER_BUILD_ARGS ?=
+
+.PHONY: image image-push image-test image-prod image-print
+
+image-print:
+	@echo "Image:    $(CONTAINER_IMAGE):$(CONTAINER_TAG)"
+	@echo "Registry: $(CONTAINER_REGISTRY)  (project: $(CONTAINER_PROJECT))"
+	@echo "Env:      $(CONTAINER_ENV)"
+	@echo "Version:  $(CONTAINER_VERSION)  (from VERSION file or 'dev' fallback)"
+	@echo ""
+	@echo "Build args: $(CONTAINER_BUILD_ARGS)"
+
+image:
+	$(PODMAN) build $(CONTAINER_BUILD_ARGS) -f Dockerfile -t $(CONTAINER_IMAGE):$(CONTAINER_TAG) .
+
+# Push depends on image — rebuilds if Dockerfile/COPY targets changed; podman
+# layer cache makes subsequent pushes fast when nothing changed.
+image-push: image
+	@echo "Pushing $(CONTAINER_IMAGE):$(CONTAINER_TAG) ..."
+	@echo "(Run 'podman login $(CONTAINER_REGISTRY)' first if you haven't.)"
+	$(PODMAN) push $(CONTAINER_IMAGE):$(CONTAINER_TAG)
+
+image-test:
+	$(MAKE) image-push CONTAINER_ENV=test
+
+image-prod:
+	$(MAKE) image-push CONTAINER_ENV=prod

--- a/Makefile.am
+++ b/Makefile.am
@@ -213,8 +213,8 @@ dev-db-reset: dev-db-stop
 #   podman login harbor.oetiker.ch
 
 CONTAINER_REGISTRY ?= harbor.oetiker.ch
-CONTAINER_PROJECT  ?= oep
-CONTAINER_IMAGE    ?= $(CONTAINER_REGISTRY)/$(CONTAINER_PROJECT)/agrammon
+CONTAINER_PROJECT  ?= bfh
+CONTAINER_IMAGE    ?= $(CONTAINER_REGISTRY)/$(CONTAINER_PROJECT)/agrammon-model
 CONTAINER_VERSION  ?= $(shell cat VERSION 2>/dev/null || echo dev)
 CONTAINER_ENV      ?= test
 CONTAINER_TAG      ?= $(CONTAINER_ENV)-$(CONTAINER_VERSION)

--- a/Makefile.am
+++ b/Makefile.am
@@ -213,8 +213,8 @@ dev-db-reset: dev-db-stop
 #   podman login harbor.oetiker.ch
 
 CONTAINER_REGISTRY ?= harbor.oetiker.ch
-CONTAINER_PROJECT  ?= bfh
-CONTAINER_IMAGE    ?= $(CONTAINER_REGISTRY)/$(CONTAINER_PROJECT)/agrammon-model
+CONTAINER_PROJECT  ?= agrammon
+CONTAINER_IMAGE    ?= $(CONTAINER_REGISTRY)/$(CONTAINER_PROJECT)/model
 CONTAINER_VERSION  ?= $(shell cat VERSION 2>/dev/null || echo dev)
 CONTAINER_ENV      ?= test
 CONTAINER_TAG      ?= $(CONTAINER_ENV)-$(CONTAINER_VERSION)


### PR DESCRIPTION
## Summary

Four commits from this afternoon's k8s-prep spike on the agrammon side.
The container work is paper-exercise-ready; the ModelCache fix and the
DatasetTable highlight are real defects worth landing on their own.

- **Container: multi-stage Dockerfile + Makefile push targets** — 591 MB runtime image (down from 1.89 GB lualatex baseline). New targets: `image`, `image-push`, `image-test`, `image-prod`, `image-print` pointing at `harbor.oetiker.ch/oep/agrammon`. PR #15 of `cro-openapi-routes-from-definition` baked in (still unmerged upstream).
- **Container: add Qooxdoo frontend builder stage** — node:20 + pnpm@10.4.1 + `qx compile --target=build`. Final image 625 MB. `/` now serves the SPA shell; `/api/v1/openapi` still gates with 401.

## Verification

- Container runs end-to-end against the local dev DB (podman :55433): Cro listens, model loads cold ~40 s / warm ~0.5 s, frontend bundle (`/agrammon/index.js`, 2.7 MB) serves 200, resources serve 200, API returns 401 (auth intact).
- Image pushed to `harbor.oetiker.ch/oep/agrammon:prod-7.0.0` to validate the Makefile push path.

## Test plan

- [ ] Pull the image: `podman pull harbor.oetiker.ch/oep/agrammon:prod-7.0.0`
- [ ] Run end-to-end against a real DB (test or prod creds), confirm SPA login + a small calc + a PDF export
- [ ] On web-volki-01 (or wherever 2025.12 still runs), confirm the `use lib` line is harmless under the older Rakudo
- [ ] Review the Dockerfile choices (esp. the libssl symlinks + the PR-15 patch RUN step) before promoting to upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)