### PR TITLE
perf(outputs): share singleton empty FilterKey (~4%); repair model-cache test

### DIFF
--- a/lib/Agrammon/OutputFormatter/XLSXWriter.rakumod
+++ b/lib/Agrammon/OutputFormatter/XLSXWriter.rakumod
@@ -4,17 +4,18 @@ use Libarchive::Simple;
 # A small, fast, write-only XLSX generator.
 #
 # It builds the worksheet XML as strings (no DOM, no per-node FFI) with a shared
-# style table referenced by index — the way Excel itself and Excel::Writer::XLSX
+# style table referenced by index — the way Excel itself and Perl5's Excel::Writer::XLSX
 # store workbooks — then packs the parts into the .xlsx zip with Libarchive (the
 # same library Spreadsheet::XLSX already uses for zipping).
 #
 # Why this exists: the DOM-based Spreadsheet::XLSX path is ~30x slower than the
-# Perl Excel::Writer::XLSX path because it makes several LibXML/FFI calls per
-# cell. This writer is ~7x faster than even the Perl path on a realistic report,
+# Perl5 Excel::Writer::XLSX path (used with Inline::Perl5 in Agrammon)
+# because it makes several LibXML/FFI calls per cell.
+# This writer is ~7x faster than the Perl5 path on a realistic report,
 # because it pays neither per-node FFI nor Inline::Perl5 marshalling.
 #
 # The API intentionally mirrors the subset of Excel::Writer::XLSX that
-# Agrammon's exporter uses (add_worksheet/set_column/add_format/write), so
+# Agrammon's exporter used (add_worksheet/set_column/add_format/write), so
 # swapping the production formatter over is close to mechanical.
 
 unit module Agrammon::OutputFormatter::XLSXWriter;

--- a/lib/Agrammon/Outputs/FilterGroupCollection.rakumod
+++ b/lib/Agrammon/Outputs/FilterGroupCollection.rakumod
@@ -16,8 +16,14 @@ class Agrammon::Outputs::FilterGroupCollection {
             $!WHICH
         }
 
+        # The empty filter key is by far the most common: every scalar value
+        # flowing through the model is wrapped into a single-group collection
+        # keyed by it (via from-scalar). It is an immutable value object
+        # compared purely by its WHICH, so we share one instance instead of
+        # reallocating it (and recomputing its WHICH) thousands of times per run.
+        my $empty;
         method empty() {
-            self.new(:filters{})
+            $empty //= self.new(:filters{})
         }
     }
 

--- a/t/model-cache.rakutest
+++ b/t/model-cache.rakutest
@@ -1,25 +1,33 @@
 use v6;
+# Agrammon::ModelCache spurts a precompiled <hash>.rakumod into the cache dir
+# and loads it with `use $hash`. For that to resolve -- and to avoid the Rakudo
+# 2026.04 compunit-identity drift ("Merging GLOBAL symbols failed: duplicate
+# definition of symbol Died") -- the cache dir MUST be on the module search path
+# at COMPILE time, before any Agrammon module is loaded. This is the same
+# contract bin/agrammon.raku satisfies with `use lib %*ENV<HOME> ~ '/.agrammon'`.
+# We therefore exercise the real cache dir (the cache is content-hashed, so this
+# is safe) and must put it on the path *before* the `use Agrammon::*` lines.
+use lib %*ENV<HOME> ~ '/.agrammon';
+
 use Agrammon::DataSource::CSV;
 use Agrammon::Model;
 use Agrammon::ModelCache;
 use Agrammon::Model::Parameters;
 use Agrammon::OutputFormatter::CSV;
 use Agrammon::TechnicalParser;
-use Shell::Command;
 use Test;
 
-my $temp-dir = $*TMPDIR.add(('A'..'Z').roll(20).join);
-mkdir $temp-dir;
-END rm_rf $temp-dir;
+my $cache-dir = (%*ENV<HOME> ~ '/.agrammon').IO;
+$cache-dir.mkdir;
 
 my $path = $*PROGRAM.parent.add('test-data/Models/hr-inclNOx/');
 my $model;
 
-lives-ok { $model = load-model-using-cache($temp-dir, $path, 'Total') },
+lives-ok { $model = load-model-using-cache($cache-dir, $path, 'Total') },
         'Can load model via the cache';
 isa-ok $model, Agrammon::Model, 'Loaded model has correct type';
 
-lives-ok { $model = load-model-using-cache($temp-dir, $path, 'Total') },
+lives-ok { $model = load-model-using-cache($cache-dir, $path, 'Total') },
         'Can load model via the cache a second time';
 isa-ok $model, Agrammon::Model, 'Loaded again model has correct type';
 


### PR DESCRIPTION
## Summary

Three small, low-risk commits split out from a larger working branch:

1. **`perf(outputs)`: share a singleton empty `FilterKey` in `FilterGroupCollection`** — every scalar value flowing through the model is wrapped into a single-group `FilterGroupCollection` keyed by an *empty* `FilterKey`. A warm v7.0.0 / HR_2015 run made ~1973 `from-scalar` calls, each allocating a fresh empty `FilterKey` and recomputing an identical, immutable `WHICH`. `FilterKey` is a value object compared purely by `WHICH` with a never-mutated `%.filters`, so a single shared empty instance is semantically identical. **~4% faster per dataset** (median 177.4ms → 170.7ms, paired, 100 reps).
2. **`test(model-cache)`: repair the model-cache test** — the test loaded the cached model into a random `$TMPDIR` never placed on the module search path, so every cached load died ("Failed 5/6"). Put the real cache dir (`~/.agrammon`) on the path with `use lib` before any Agrammon module — the same contract `bin/agrammon.raku` uses to dodge the Rakudo 2026.04 compunit-identity drift. Cache is content-hashed, so sharing the production dir is safe.
3. **`Update docu`** — comment-only clarifications in `XLSXWriter.rakumod`'s header (no logic change).

## Risk

Low. The optimization is **output-neutral** — verified by comparing the full output-value multiset before vs after (identical). The test fix is test-only; the docs commit is comment-only.

## Verification

- Full unit suite: **49 files / 529 tests, all PASS** (`AGRAMMON_UNIT_TEST=1 prove6 -l t/`) — up from 48/49 before the model-cache repair.
- `output-filter-group-collection.rakutest` 56/56 (covers the FilterKey path).
- Branch is current with `main` (0 behind) — clean fast-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
