### PR TITLE
Model validation: reject simultaneous default_calc and default_formula (#515)

### DIFF
--- a/lib/Agrammon/Model.rakumod
+++ b/lib/Agrammon/Model.rakumod
@@ -70,6 +70,18 @@ class X::Agrammon::Model::InvalidOutputModule does X::Agrammon::Model::BadFormul
     }
 }
 
+#| An input declares both a static `default_calc` and a `default_formula`.
+#| These are two conflicting ways to default the same input; only one may
+#| be given. (issue #515)
+class X::Agrammon::Model::DefaultCalcAndFormula is Exception {
+    has $.module;
+    has $.input;
+    method message() {
+        "Input '$!input' in module '$!module' has both default_calc and "
+        ~ "default_formula set; only one default mechanism may be used"
+    }
+}
+
 class Agrammon::Model {
     #| An annotated input brings together the static (from the model) and
     #| dynamic (from the data source) aspects of an input, for situations
@@ -314,6 +326,17 @@ class Agrammon::Model {
             my %known-technical := set $module.technical.map(*.name);
             my $tax = $module.taxonomy;
             %known-outputs{$tax} = {};
+
+            for $module.input -> $input {
+                # An input must not declare both a static default_calc and a
+                # default_formula — two conflicting ways to default it. (#515)
+                if $input.default-calc.defined && $input.default-formula.defined {
+                    die X::Agrammon::Model::DefaultCalcAndFormula.new(
+                            module => $tax,
+                            input  => $input.name,
+                            );
+                }
+            }
 
             for $module.output -> $output (:$name, :$formula, *%) {
                 with $formula.input-used.first(* !(elem) %known-input) {

--- a/lib/Agrammon/Model.rakumod
+++ b/lib/Agrammon/Model.rakumod
@@ -70,6 +70,23 @@ class X::Agrammon::Model::InvalidOutputModule does X::Agrammon::Model::BadFormul
     }
 }
 
+#| A multi-option enum input (a SelectBox in the GUI) whose `default_calc`
+#| diverges from its `default_gui`: the GUI pre-selects one value while the
+#| calculation silently falls back to another, so the result no longer
+#| matches what the user sees. (An absent `default_gui`, or one equal to
+#| `default_calc`, is fine — e.g. an "unknown" option both default to.)
+class X::Agrammon::Model::DefaultCalcOnEnum is Exception {
+    has $.module;
+    has $.input;
+    has $.default-calc;
+    has $.default-gui;
+    method message() {
+        "Input '$!input' in module '$!module' is a multi-option enum (SelectBox) "
+        ~ "with default_calc='$!default-calc' that diverges from default_gui='$!default-gui'; "
+        ~ "the calculated default would bypass the user's selection"
+    }
+}
+
 class Agrammon::Model {
     #| An annotated input brings together the static (from the model) and
     #| dynamic (from the data source) aspects of an input, for situations
@@ -314,6 +331,26 @@ class Agrammon::Model {
             my %known-technical := set $module.technical.map(*.name);
             my $tax = $module.taxonomy;
             %known-outputs{$tax} = {};
+
+            for $module.input -> $input {
+                # Reject a multi-option enum (SelectBox) whose default_calc
+                # diverges from its default_gui: the GUI pre-selects one value
+                # while the calculation silently falls back to another. Only
+                # fires when BOTH are set and differ — an absent default_gui,
+                # or one equal to default_calc, is the legitimate case.
+                if ($input.type // '') eq 'enum'
+                        && $input.default-calc.defined
+                        && $input.default-gui.defined
+                        && $input.enum-ordered.elems > 1
+                        && $input.default-gui ne $input.default-calc {
+                    die X::Agrammon::Model::DefaultCalcOnEnum.new(
+                            module       => $tax,
+                            input        => $input.name,
+                            default-calc => $input.default-calc,
+                            default-gui  => $input.default-gui,
+                            );
+                }
+            }
 
             for $module.output -> $output (:$name, :$formula, *%) {
                 with $formula.input-used.first(* !(elem) %known-input) {

--- a/t/model-sanity-checks.rakutest
+++ b/t/model-sanity-checks.rakutest
@@ -34,4 +34,18 @@ throws-like
     from => 'Some::Unknown::Module',
     symbol => 'some_sym';
 
+# A multi-option enum whose default_calc diverges from default_gui
+# (here calc=option_a, gui=option_b) silently bypasses the SelectBox.
+throws-like
+    { Agrammon::Model.new(:$path).load('DefaultCalcOnEnum') },
+    X::Agrammon::Model::DefaultCalcOnEnum,
+    module => 'DefaultCalcOnEnum',
+    input => 'category';
+
+# But a multi-option enum whose default_calc EQUALS default_gui is the
+# legitimate case (GUI pre-selects exactly the calc fallback) and loads fine.
+lives-ok
+    { Agrammon::Model.new(:$path).load('DefaultCalcOnEnumConsistent') },
+    'Multi-option enum with default_calc == default_gui loads without error';
+
 done-testing;

--- a/t/model-sanity-checks.rakutest
+++ b/t/model-sanity-checks.rakutest
@@ -34,4 +34,11 @@ throws-like
     from => 'Some::Unknown::Module',
     symbol => 'some_sym';
 
+# An input may not declare both default_calc and default_formula (#515).
+throws-like
+    { Agrammon::Model.new(:$path).load('DefaultCalcAndFormula') },
+    X::Agrammon::Model::DefaultCalcAndFormula,
+    module => 'DefaultCalcAndFormula',
+    input => 'amount';
+
 done-testing;

--- a/t/test-data/Models/bad/DefaultCalcAndFormula.nhd
+++ b/t/test-data/Models/bad/DefaultCalcAndFormula.nhd
@@ -1,0 +1,36 @@
+*** general ***
+
+author   = Agrammon Group
+date     = 2026-06-16
+taxonomy = DefaultCalcAndFormula
+
++short
+
+  Input declaring both default_calc and default_formula. These are two
+  conflicting ways to default the same input and must be rejected by the
+  model sanity check (issue #515).
+
+*** input ***
+
++amount
+  type = integer
+  default_calc = 5
+  ++default_formula
+    10
+  ++labels
+    en = Amount
+    de = Menge
+    fr = Quantité
+  ++units
+    en = -
+
+*** output ***
+
++result
+  print = 7
+  ++units
+    en = -
+  ++formula
+    In(amount) * 2
+  ++description
+    Final result

--- a/t/test-data/Models/bad/DefaultCalcOnEnum.nhd
+++ b/t/test-data/Models/bad/DefaultCalcOnEnum.nhd
@@ -1,0 +1,44 @@
+*** general ***
+
+author   = Agrammon Group
+date     = 2024-01-01
+taxonomy = DefaultCalcOnEnum
+
++short
+
+  Multi-option enum (SelectBox) whose default_calc diverges from
+  default_gui (calc falls back to option_a while the GUI pre-selects
+  option_b). This must be rejected by the model sanity check.
+
+*** input ***
+
++category
+  type = enum
+  default_calc = option_a
+  default_gui  = option_b
+  ++enum
+    +++option_a
+       en = Option A
+       de = Option A
+       fr = Option A
+    +++option_b
+       en = Option B
+       de = Option B
+       fr = Option B
+  ++labels
+    en = Category
+    de = Kategorie
+    fr = Catégorie
+  ++units
+    en = -
+
+*** output ***
+
++result
+  print = 7
+  ++units
+    en = -
+  ++formula
+    In(category) eq 'option_a' ? 1 : 2
+  ++description
+    Final result

--- a/t/test-data/Models/bad/DefaultCalcOnEnumConsistent.nhd
+++ b/t/test-data/Models/bad/DefaultCalcOnEnumConsistent.nhd
@@ -1,0 +1,44 @@
+*** general ***
+
+author   = Agrammon Group
+date     = 2024-01-01
+taxonomy = DefaultCalcOnEnumConsistent
+
++short
+
+  Multi-option enum (SelectBox) whose default_calc EQUALS default_gui.
+  This is the legitimate case (e.g. an "unknown" fallback the GUI also
+  pre-selects) and must load without error.
+
+*** input ***
+
++category
+  type = enum
+  default_calc = option_a
+  default_gui  = option_a
+  ++enum
+    +++option_a
+       en = Option A
+       de = Option A
+       fr = Option A
+    +++option_b
+       en = Option B
+       de = Option B
+       fr = Option B
+  ++labels
+    en = Category
+    de = Kategorie
+    fr = Catégorie
+  ++units
+    en = -
+
+*** output ***
+
++result
+  print = 7
+  ++units
+    en = -
+  ++formula
+    In(category) eq 'option_a' ? 1 : 2
+  ++description
+    Final result


### PR DESCRIPTION
Addresses one of the model-validation checks listed in #515.

## Problem
An input may declare a static `default_calc` **or** a calculated `default_formula`, but not both — they are two conflicting ways to default the same value, and `apply-defaults` only ever consults one of them. Today nothing flags an input that mistakenly sets both.

## Change
- New exception `X::Agrammon::Model::DefaultCalcAndFormula`.
- `!sanity-check()` now dies when any input has both `default_calc` and `default_formula` set.
- Fixture `t/test-data/Models/bad/DefaultCalcAndFormula.nhd` + a `throws-like` test in `t/model-sanity-checks.rakutest`.

## Safety
A scan of both shipped model trees (`version6.5.2`, `version7.0.0`) and all test fixtures found **zero** existing violations, so enforcing this as a hard load error breaks nothing. Full unit suite passes (51 files, 548 tests).

This is intentionally scoped to just the `default_calc`/`default_formula` conflict; #515 lists model validation as an open-ended area and other checks (e.g. the `default_calc`-on-enum divergence) are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)