### PR TITLE
Name source model variant + URL in dataset-sent emails (#571)

### DIFF
--- a/lib/Agrammon/Web/Service.rakumod
+++ b/lib/Agrammon/Web/Service.rakumod
@@ -79,6 +79,9 @@ class Agrammon::Web::Service {
             my $subject = $sent == 1 ?? %lx{'new dataset'}[0]  !! %lx{'new dataset'}[1];
             my $format  = $sent == 1 ?? %lx{'dataset sent'}[0] !! %lx{'dataset sent'}[1];
             my $msg     = sprintf $format, @datasets.join(', '), $sender;
+            # #571: name the source model variant + URL so the recipient knows
+            # which Agrammon instance the dataset came from.
+            $msg ~= "\n\n" ~ self!model-info-line($language);
             Agrammon::Email.new(
                 :to($recipient),
                 :from('support@agrammon.ch'),
@@ -143,6 +146,9 @@ class Agrammon::Web::Service {
             my $subject = %lx<dataset> ~ ": $new-dataset";
             my $format = %lx{'dataset sent'}[0];
             my $msg = sprintf $format, $new-dataset, %params<username>;
+            # #571: name the source model variant + URL so the recipient knows
+            # which Agrammon instance the dataset came from.
+            $msg ~= "\n\n" ~ self!model-info-line(%params<language> // 'de');
             Agrammon::Email.new(
                 :to($recipientMail),
                 :from('support@agrammon.ch'),
@@ -152,6 +158,17 @@ class Agrammon::Web::Service {
                 :filename($new-dataset.subst(/<-[\w_.-]>/, '', :g) ~ '.pdf')
             ).send;
         }
+    }
+
+    #| #571: one localized line naming the source model variant and its URL,
+    #| appended to dataset-sent emails so the recipient can tell which Agrammon
+    #| instance (Single/Regional/Kantonal, version) a dataset came from.
+    method !model-info-line(Str $language) {
+        my %lx     = $!cfg.translations{$language} // $!cfg.translations<en>;
+        my %titles = $!cfg.gui-title;
+        my $title  = %titles{$language} // %titles<en> // $!cfg.gui-variant;
+        my $url    = $!cfg.gui-url // '';
+        return sprintf %lx{'dataset model info'}, $title, $url;
     }
 
     method store-dataset-comment(Agrammon::Web::SessionUser $user, Str $name, $comment) {

--- a/share/translations/de.po
+++ b/share/translations/de.po
@@ -3,6 +3,9 @@ msgid_plural "datasets sent"
 msgstr[0] "Der Datensatz %s von %s wurde Ihnen in Ihrem Agrammon Konto bereit gestellt"
 msgstr[1] "Die Datensätze %s von %s wurden Ihnen in Ihrem Agrammon Konto bereit gestellt"
 
+msgid "dataset model info"
+msgstr "Dieser Datensatz stammt von %s (%s)."
+
 msgid "new dataset"
 msgid_plural "new datasets"
 msgstr[0] "Neuer Agrammon Datensatz"

--- a/share/translations/en.po
+++ b/share/translations/en.po
@@ -3,6 +3,9 @@ msgid_plural "datasets sent"
 msgstr[0] "The dataset %s of %s was copied into your Agrammon account"
 msgstr[1] "The dataset %s of %s were copied into your Agrammon account"
 
+msgid "dataset model info"
+msgstr "This dataset is from %s (%s)."
+
 msgid "new dataset"
 msgid_plural "new datasets"
 msgstr[0] "New Agrammon dataset"

--- a/share/translations/fr.po
+++ b/share/translations/fr.po
@@ -3,6 +3,8 @@ msgid_plural "datasets sent"
 msgstr[0] "Le sete de données %s de %s ont été copiés dans votre compte".
 msgstr[1] "Les setes de données %s de %s a été copiés dans votre compte".
 
+msgid "dataset model info"
+msgstr "Ce jeu de données provient de %s (%s)."
 
 msgid "new dataset"
 msgid_plural "new datasets"


### PR DESCRIPTION
Closes #571.

Recipients of a sent or submitted dataset had no indication of which Agrammon instance (Single/Regional/Kantonal, version) it came from — confusing when a recipient receives datasets from several deployments. This appends one localized line naming the source model and its URL to the dataset-sent emails.

Example (per recipient language):
```
This dataset is from AGRAMMON 7.0.0 Single Farm Model (https://model.agrammon.ch/single/...).
Dieser Datensatz stammt von AGRAMMON 7.0.0 Einzelbetriebsmodell (...).
Ce jeu de données provient de AGRAMMON 7.0.0 modèle Exploitation individuelle (...).
```

## Changes
- New `dataset model info` translation key in `de`/`en`/`fr` `.po` files.
- New private `Agrammon::Web::Service!model-info-line($language)` building the line from `Config.gui-title` (localized, `%VERSION%`-resolved) and `Config.gui-url` (the deployment's `GUI.baseUrl`).
- Appended in **both** email paths: `send-datasets` (user-to-user) and `submit-dataset` (submission to a configured recipient).

## Testing
- `Service.rakumod` compiles; the line renders correctly in de/en/fr against a real config.
- No behaviour change to existing tests — the email build sits behind the `AGRAMMON_TESTING` guard, so the message text isn't exercised by the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)