### PR TITLE
Drop redundant enum field from input metadata (#301)

### DIFF
--- a/lib/Agrammon/Model/Input.rakumod
+++ b/lib/Agrammon/Model/Input.rakumod
@@ -140,7 +140,10 @@ class Agrammon::Model::Input {
                 gui => $.default-gui,
                 hasFormula => $.default-formula.defined,
             )),
-            :enum(%!enum-lookup),
+            # NB: the enum value set is sent as @options (keys + neutral labels)
+            # + optionsLang (per-language labels); the old `enum` lookup hash
+            # duplicated that and was unused by the GUI (#301). enumAliases stays
+            # — it serves a different purpose (cross-version value mapping).
             :enumAliases(%!enum-aliases),
             :$!filter,
             :%!help,

--- a/share/agrammon.openapi
+++ b/share/agrammon.openapi
@@ -703,10 +703,6 @@ components:
                             anyOf:
                                 - type: string
                                 - type: number
-                enum:
-                    description: Elements of select box
-                    type: object
-                    additionalProperties: true
                 gui:
                     description: GUI navigation label
                     $ref: '#/components/schemas/LanguageLabels'


### PR DESCRIPTION
Closes #301.

`Agrammon::Model::Input.as-hash` sent the enum value set three ways: the `enum` lookup hash plus `options` + `optionsLang`. "One should be enough" (the issue).

The GUI uses `options`/`optionsLang` (dropdown render/edit in `PropTable`, `ConfigEditor`, `BranchEditor`) and `enumAliases` (cross-version value mapping). The `enum` hash is **not referenced anywhere in the frontend** — pure duplication.

## Change
- Remove `:enum(%!enum-lookup)` from `Input.as-hash` (kept `enumAliases`, `options`, `optionsLang`).
- Remove the corresponding `enum` property from the OpenAPI input-variables schema. No external API client depends on it (confirmed with the maintainer).

## Verification
- `as-hash` on a real enum input now returns `enumAliases`/`options`/`optionsLang` and no `enum`; model loads fine.
- No Raku consumer reads the input `enum` field; OpenAPI still parses.

Note: the sibling refactor #420 (remove the instance name from the PropTable variable column) was scoped out of this PR — it's a persistence-critical frontend change best done with GUI verification, and the underlying bug is already prevented by the existing workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)