### PR TITLE
Resolve value-edit saves against the folder's current instance (#420, step 1)

### DIFF
--- a/frontend/source/class/agrammon/module/input/NavFolder.js
+++ b/frontend/source/class/agrammon/module/input/NavFolder.js
@@ -434,6 +434,24 @@ qx.Class.define('agrammon.module.input.NavFolder', {
           * @return {var} TODOC
           * @lint ignoreDeprecated(alert)
           */
+        // #420: return the authoritative, instance-qualified variable name for
+        // `name` within this folder, matched on the instance-independent part
+        // (the name with any [instance] marker stripped). The folder's propData
+        // carries the current instance (this folder is the single source of
+        // truth for it), so a caller can pass a name whose [instance] is stale
+        // — e.g. a table cell that lags an instance rename — and still get the
+        // name pointing at this folder's *current* instance. Returns null if no
+        // variable matches. Singletons (no [instance]) round-trip unchanged.
+        resolveVariable: function(name) {
+            var bare = ('' + name).replace(/\[[^\]]*\]/, '');
+            for (var i = 0; i < this.__propData.length; i++) {
+                if (this.__propData[i].getName().replace(/\[[^\]]*\]/, '') === bare) {
+                    return this.__propData[i].getName();
+                }
+            }
+            return null;
+        }, // resolveVariable
+
         setData: function(key, value, comment, noCheck, branch_values) {
             var i, ii, len, len2, option, found,
                 options, metaData, msg;

--- a/frontend/source/class/agrammon/module/input/PropTable.js
+++ b/frontend/source/class/agrammon/module/input/PropTable.js
@@ -383,6 +383,15 @@ qx.Class.define('agrammon.module.input.PropTable', {
             }
             var tableModel = this.__propertyEditor.getTableModel();
             var varname = tableModel.getValue(0, fR);
+            // #420: resolve against the current folder's authoritative instance
+            // so a value edit always saves to the folder's *current* instance,
+            // even if the table cell still carries a pre-rename [instance].
+            // Without this, "rename instance, then immediately change a value"
+            // wrote to the old name and spawned a phantom instance in the DB.
+            var resolved = this.__currentFolder.resolveVariable(varname);
+            if (resolved) {
+                varname = resolved;
+            }
             var value   = tableModel.getValue(this.__valueColumn, fR);
             var comment = tableModel.getValue(this.__commentColumn, fR);
             if (value != null) {


### PR DESCRIPTION
First step toward #420.

The PropTable value column (col 0) carries the full instance-qualified variable name (`Module[instance]::…::var`). After an instance rename, that table cell could still hold the old `[instance]`; an immediate value edit then saved under the old name and **spawned a phantom instance in the DB** (only visible after reload). The previous mitigation kept the column in sync on rename; this addresses the fragility at its root for the value path.

## Change
- New `NavFolder.resolveVariable(name)` — matches a variable on its instance-independent part and returns the folder's **current** authoritative instance-qualified name (the `NavFolder` is the single source of truth for the instance). Singletons round-trip unchanged; returns `null` if unmatched.
- `PropTable.__dataChanged_func` resolves the edited variable through it before updating the client model and issuing the `store_data` RPC — so the save always targets the folder's current instance regardless of the table cell's state.

## Scope
This is **step 1** (the value-edit path, where the original data bug occurred). The comment (`VariableComment`) and branch (`BranchEditor`) persistence paths still read col 0 directly and are unchanged; fully removing the instance from the column across all paths is a planned follow-up.

## Testing
Verified locally: rename an instance, immediately change an input value on it, reload — the value persists on the renamed instance and no duplicate/phantom instance is created. Normal edits on non-renamed instances and singletons still save correctly. Frontend source target compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)