### PR TITLE
Remove instance name from PropTable column; drop rename-sync (#420, step 2)

### DIFF
--- a/frontend/source/class/agrammon/module/input/NavFolder.js
+++ b/frontend/source/class/agrammon/module/input/NavFolder.js
@@ -47,6 +47,12 @@ qx.Class.define('agrammon.module.input.NavFolder', {
         }
         this.__type         = type;
         this.__folderName   = folderName;
+        // #420: the instance name is the single source of truth for this
+        // folder's instance. Derive it from the folderName here (e.g.
+        // "Module[Stall 1]" -> "Stall 1"); updated on rename in setName.
+        // null for singleton / non-instance folders.
+        var instMatch = ('' + folderName).match(/\[(.*)\]/);
+        this.__instanceName = instMatch ? instMatch[1] : null;
         this.__propData     = new Array;
         this.__childrenHash = new Object;
         this.__instanceOrder = instanceOrder;
@@ -62,6 +68,7 @@ qx.Class.define('agrammon.module.input.NavFolder', {
         __type: null,
         __parent: null,
         __folderName: null,
+        __instanceName: null,
         __labels: null,
         __propData: null,
         __childrenHash: null,
@@ -134,19 +141,15 @@ qx.Class.define('agrammon.module.input.NavFolder', {
             return this.__folderName;
         }, // getName
 
-        __updateVariableNames : function(newInstanceName) {
-            var data = this.__propData;
-            for (let row of data) {
-                let oldName = row.getName();
-                let newName = oldName.replace(/\[.+\]/, '[' + newInstanceName + ']');
-                row.setName(newName);
-            }
-        },
-
         setName: function(newName, propEditor) {
             this.__folderName = newName;
-            this.__updateVariableNames(newName);
-            // set this folders data in propEditor table
+            // #420: the folder is the single source of truth for its instance.
+            // Record the new instance here; resolveVariable() re-qualifies the
+            // (instance-free) variable names against it on demand, so we no
+            // longer rewrite the [instance] into every variable name on rename
+            // (the old __updateVariableNames workaround).
+            this.__instanceName = newName;
+            // rebuild this folder's data in the propEditor table
             propEditor.setData(this, this.__propData);
             this.setLabel(newName);
         }, // setName
@@ -445,8 +448,15 @@ qx.Class.define('agrammon.module.input.NavFolder', {
         resolveVariable: function(name) {
             var bare = ('' + name).replace(/\[[^\]]*\]/, '');
             for (var i = 0; i < this.__propData.length; i++) {
-                if (this.__propData[i].getName().replace(/\[[^\]]*\]/, '') === bare) {
-                    return this.__propData[i].getName();
+                var full = this.__propData[i].getName();
+                if (full.replace(/\[[^\]]*\]/, '') === bare) {
+                    // Re-qualify using this folder's current instance (single
+                    // source of truth). The stored name supplies only the
+                    // [instance] *position*; its value may be stale after a
+                    // rename since we no longer rewrite it eagerly.
+                    return this.__instanceName != null
+                        ? full.replace(/\[[^\]]*\]/, '[' + this.__instanceName + ']')
+                        : full;
                 }
             }
             return null;
@@ -462,7 +472,13 @@ qx.Class.define('agrammon.module.input.NavFolder', {
             }
             for (i=0; i<len ; i++) {
                 var varName = this.__propData[i].getName();
-                if (varName == key) {
+                // #420: match on the instance-independent name. The stored
+                // variable name's [instance] may be stale after a rename (we no
+                // longer rewrite it), and callers may pass either the bare name
+                // or a freshly re-qualified one — compare with the marker
+                // stripped from both sides. Bare names are unique within a
+                // folder, so this stays unambiguous.
+                if (('' + varName).replace(/\[[^\]]*\]/, '') == ('' + key).replace(/\[[^\]]*\]/, '')) {
 
                     // check for enum changes between dataset and model
                     metaData = null;

--- a/frontend/source/class/agrammon/module/input/PropTable.js
+++ b/frontend/source/class/agrammon/module/input/PropTable.js
@@ -566,6 +566,10 @@ qx.Class.define('agrammon.module.input.PropTable', {
             var tm = this.__propertyEditor.getTableModel();
             if (col == this.__commentColumn ) {
                 var varName = tm.getValue(4, row);
+                // #420: the comment editor reads the (now instance-free)
+                // variable from column 0; give it the current folder so it can
+                // resolve back to the folder's current instance for the RPC.
+                this.__commentEditor.setFolder(this.__currentFolder);
                 this.__commentEditor.open(varName);
                 return;
             }
@@ -602,7 +606,12 @@ qx.Class.define('agrammon.module.input.PropTable', {
                         metaData.optionsLang['key'] = opt;
                         options.push(metaData.optionsLang);
                         labels.push(tm.getValue(4, i));
-                        vars.push(tm.getValue(0, i));
+                        // #420: column 0 is now the instance-free variable name;
+                        // BranchEditor needs the instance-qualified name (it
+                        // extracts the instance via regex), so resolve it back
+                        // through the current folder.
+                        var bareVar = tm.getValue(0, i);
+                        vars.push(this.__currentFolder.resolveVariable(bareVar) || bareVar);
                     }
                 }
                 var branchEditor = new agrammon.module.input.regional.BranchEditor(

--- a/frontend/source/class/agrammon/module/input/Variable.js
+++ b/frontend/source/class/agrammon/module/input/Variable.js
@@ -55,7 +55,12 @@ qx.Class.define('agrammon.module.input.Variable', {
             var rec = new Array;
             var locale = qx.locale.Manager.getInstance().getLocale();
             locale = locale.replace(/_.+/,'');
-            rec.push(this.getName());
+            // #420: the PropTable variable column no longer carries the
+            // [instance] marker — the instance lives only in the NavFolder.
+            // Persistence resolves the bare name back to the folder's current
+            // instance via NavFolder.resolveVariable(), so an instance rename
+            // can never leave a stale instance in this column.
+            rec.push(this.getName().replace(/\[[^\]]*\]/, ''));
             rec.push(this.getLabels().en);
             rec.push(this.getLabels().de);
             rec.push(this.getLabels().fr);

--- a/frontend/source/class/agrammon/module/input/VariableComment.js
+++ b/frontend/source/class/agrammon/module/input/VariableComment.js
@@ -20,8 +20,23 @@ qx.Class.define('agrammon.module.input.VariableComment', {
 
     members : {
 
+        __folder: null,
+
+        // #420: the NavFolder whose instance the comment belongs to, set by
+        // PropTable when the editor is opened. Used to resolve the instance-free
+        // column-0 name back to the folder's current instance.
+        setFolder: function(folder) {
+            this.__folder = folder;
+        },
+
         _storeComment: function(comment) {
             var variable = this._tableModel.getValue(0, this._commentRow);
+            // #420: column 0 no longer carries the [instance]; resolve it back
+            // to the folder's current instance so the comment is stored on the
+            // right instance (and survives an instance rename).
+            if (this.__folder) {
+                variable = this.__folder.resolveVariable(variable) || variable;
+            }
             var dataset  = this._info.getDatasetName();
             this._rpc.callAsync(qx.lang.Function.bind(
                 this._storeCommentFunc,this),


### PR DESCRIPTION
Completes #420 (step 1 was #647).

The PropTable variable column carried the full instance-qualified name, duplicating the instance that the `NavFolder` already owns. Keeping the two in sync on rename required the `__updateVariableNames` workaround, and any gap let a value/comment save target the wrong (old) instance — the corruption #420 describes.

Make the `NavFolder` the single source of truth for its instance:

- `Variable.getRow`: column 0 is now the **instance-free** variable name.
- `NavFolder` tracks `__instanceName` (parsed from the folder name at construction, updated in `setName`); `resolveVariable()` re-qualifies a bare name to the folder's **current** instance on demand (using the stored name only for the `[instance]` position).
- All persistence resolves the column-0 name through the folder before use: value edits (step 1), comments (`VariableComment`, given the folder on open), and branch data (`BranchEditor` still needs the qualified name).
- `setData` matches on the instance-independent name (bare names are unique within a folder), so a stale stored `[instance]` no longer matters.
- Drop `__updateVariableNames` and its rename-time call — the instance is no longer written into each variable name.

`getBranchRow` (regional `ConfigEditor`) intentionally keeps the full name.

## Testing
Verified locally on the single-farm GUI: value edit, rename-then-edit, comment, and reload all behave; no phantom instances. Frontend source target compiles clean.

Note: separate, pre-existing regional-GUI bugs (folder-ownership in `__clearTree`, the `__loadDatasetFunction` parser not defending against bracketed instance names, and some corrupted local test data) were uncovered while testing and confirmed to reproduce on `main` without this change — they're tracked separately and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)