### PR TITLE
Fix regional dataset load crash and cross-variant delete data loss

### DIFF
--- a/frontend/source/class/agrammon/module/input/NavBar.js
+++ b/frontend/source/class/agrammon/module/input/NavBar.js
@@ -932,7 +932,15 @@ qx.Class.define('agrammon.module.input.NavBar', {
             Object.values(this.__navHash).forEach(entry => {
                 let navFolder = entry.folder;
                 if (navFolder.getName() != 'root') {
-                    this.removeOwnedQxObject(navFolder);
+                    // Folders added outside __createNavFolder — e.g. regional
+                    // instance folders created in ConfigInstance via
+                    // `new NavFolder` + the agrammon.NavBar.addFolder message —
+                    // were never addOwnedQxObject'd and have no qxObjectId.
+                    // Calling removeOwnedQxObject on them throws "not owned by
+                    // this", so only release the ones we actually own.
+                    if (navFolder.getQxObjectId() != null) {
+                        this.removeOwnedQxObject(navFolder);
+                    }
                     navFolder.destroy();
                 }
             });

--- a/lib/Agrammon/DB/Datasets.rakumod
+++ b/lib/Agrammon/DB/Datasets.rakumod
@@ -74,17 +74,26 @@ class Agrammon::DB::Datasets does Agrammon::DB::Variant {
     }
 
     method delete(@datasets) {
-        my $deleted;
+        my $deleted = 0;
         my $user = $!user.id;
+        # Scope the delete to the active variant exactly like `load` above:
+        # dataset names are only unique per (name, pers, version, modelvariant,
+        # guivariant), so deleting by (pers, name) alone wipes same-named
+        # datasets in *other* variants/versions that the GUI never showed.
+        my @versions = (%!agrammon-variant<version>, |self!compatible-versions);
+        my (Str $gui, Str $model) = %!agrammon-variant<gui model>;
         for @datasets -> $ds {
             self.with-db: -> $db {
-                my $results = $db.query(q:to/DATASET/, $user, $ds);
+                my $results = $db.query(q:to/DATASET/, $user, $ds, @versions, $gui, $model);
                     DELETE FROM dataset
-                     WHERE dataset_pers = $1
-                       AND dataset_name = $2
+                     WHERE dataset_pers      = $1
+                       AND dataset_name      = $2
+                       AND dataset_version   = ANY($3)
+                       AND (dataset_model = 'UNKNOWN'
+                            OR dataset_guivariant = $4 AND dataset_modelvariant = $5)
                     RETURNING dataset_id
                 DATASET
-                $deleted++ if $results.value;
+                $deleted += $results.rows;
             }
         }
         return $deleted;

--- a/t/dataset.rakutest
+++ b/t/dataset.rakutest
@@ -1,6 +1,7 @@
 use v6;
 use Agrammon::Config;
 use Agrammon::DB::Dataset;
+use Agrammon::DB::Datasets;
 use Agrammon::DB::User;
 use Agrammon::Web::SessionUser;
 use DB::Pg;
@@ -9,7 +10,7 @@ use Test;
 use lib 't/lib';
 use AgrammonTest;
 
-plan 14;
+plan 16;
 
 if %*ENV<AGRAMMON_UNIT_TEST> {
     skip-rest 'Not a unit test';
@@ -254,6 +255,58 @@ transactionally {
         );
         is-deeply $results<options>,   @options-expected,   "Got correct options";
         is-deeply $results<fractions>, @fractions-expected, "Got correct fractions";
+    }
+
+    # Regression: Agrammon::DB::Datasets.delete must scope by the active
+    # variant, not just (pers, name). Datasets are unique per
+    # (name, pers, version, modelvariant, guivariant), so a user may hold
+    # same-named datasets in different GUI variants; the Regional GUI filters
+    # by guivariant on load, but delete used to key on (pers, name) only and
+    # silently wiped the same-named datasets in *other* variants the GUI never
+    # showed. See Agrammon::DB::Datasets.delete / .load.
+    sub names-for($user, %variant, $name) {
+        Agrammon::DB::Datasets.new(:$user, :agrammon-variant(%variant))
+            .load.collection.grep(*.name eq $name).elems;
+    }
+
+    subtest 'delete() is scoped to guivariant (no cross-variant deletion)' => {
+        plan 4;
+        my %single   = (version => '6.0', gui => 'Single',   model => 'Base');
+        my %regional = (version => '6.0', gui => 'Regional', model => 'Base');
+        my $name = 'ScopeVariant';
+
+        Agrammon::DB::Dataset.new(:$name, :$user, :agrammon-variant(%single)).create;
+        Agrammon::DB::Dataset.new(:$name, :$user, :agrammon-variant(%regional)).create;
+
+        is names-for($user, %single,   $name), 1, 'Single-variant dataset exists before delete';
+        is names-for($user, %regional, $name), 1, 'Regional-variant dataset exists before delete';
+
+        my $deleted = Agrammon::DB::Datasets.new(:$user, :agrammon-variant(%single)).delete([$name]);
+        is $deleted, 1, 'Exactly one dataset deleted — only the active (Single) variant';
+
+        is names-for($user, %regional, $name), 1,
+            'Same-named dataset in another guivariant is NOT deleted';
+    }
+
+    subtest 'delete() is scoped to owner (no cross-user deletion)' => {
+        plan 3;
+        my %variant = (version => '6.0', gui => 'Single', model => 'Base');
+        my $name = 'ScopeOwner';
+
+        my $user2 = Agrammon::DB::User.new(
+            :username<agtest2>, :firstname<YF>, :lastname<YL>,
+            :organisation<YO>, :password<YP123456>,
+        );
+        $user2.activate-account($user2.create-account('user'));
+
+        Agrammon::DB::Dataset.new(:$name, :user($user),  :agrammon-variant(%variant)).create;
+        Agrammon::DB::Dataset.new(:$name, :user($user2), :agrammon-variant(%variant)).create;
+
+        my $deleted = Agrammon::DB::Datasets.new(:user($user), :agrammon-variant(%variant)).delete([$name]);
+        is $deleted, 1, "Exactly one dataset deleted — only the requesting user's";
+
+        is names-for($user,  %variant, $name), 0, "Requesting user's dataset is deleted";
+        is names-for($user2, %variant, $name), 1, "Other user's same-named dataset is NOT deleted";
     }
 
 # TODO


### PR DESCRIPTION
Two pre-existing bugs in the Regional GUI dataset path, independent of the #420 work and reproducible on clean `main`. Production is unaffected because its datasets don't have the triggering instance/variant combinations; the bugs surface in local/dev datasets.

## 1. Dataset load crash — `NavBar.__clearTree`
Loading a dataset after a regional instance folder had been created threw:

> Cannot discard object because it is not owned by this

Regional instance folders are added via `ConfigInstance` (`new NavFolder` + the `agrammon.NavBar.addFolder` message) and never go through `__createNavFolder`, so they were never `addOwnedQxObject`'d and have no `qxObjectId`. `__clearTree` then called `removeOwnedQxObject` on them → throw. Fix: guard the release so only owned folders are passed to `removeOwnedQxObject`.

## 2. Cross-variant delete data loss — `Agrammon::DB::Datasets.delete`
`delete` keyed only on `(dataset_pers, dataset_name)`, while `load`/`get_datasets` scope by version + guivariant + modelvariant. Datasets are unique per `(name, pers, version, modelvariant, guivariant)`, so a user can legitimately hold same-named datasets across GUI variants. Deleting the one shown in the (variant-filtered) GUI **silently deleted the same-named datasets in the other variants the GUI never showed** — e.g. deleting a Regional "Test" also removed a Single "Test".

Fix: scope the delete to the active variant, mirroring `load` (`dataset_version = ANY(...) AND (dataset_model = 'UNKNOWN' OR dataset_guivariant = ... AND dataset_modelvariant = ...)`), and count actually-deleted rows.

## Tests
`t/dataset.rakutest` gains two regression subtests on `Datasets.delete`:
- **scoped to guivariant** — creates same-named Single + Regional datasets, deletes Single, asserts Regional survives. Proven to fail (`not ok - Same-named dataset in another guivariant is NOT deleted`) when the delete fix is reverted.
- **scoped to owner** — creates same-named datasets for two users, asserts the other user's survives (passes pre-fix too; locks in the existing owner scoping).

Both fixes verified in the Regional v7.0.0 GUI; suite green (`t/dataset.rakutest` 16/16, `t/webservice.rakutest` delete subtest passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)