### PR TITLE
Remove deprecated qx.io.remote dependency (#643)

### DIFF
--- a/frontend/Manifest.json
+++ b/frontend/Manifest.json
@@ -23,7 +23,6 @@
   },
   "requires": {
     "@qooxdoo/framework": "^7.8.0",
-    "qooxdoo/deprecated.qx.io.remote": "^1.0.2",
     "johnspackman/UploadMgr": "^2.0.0",
     "maettu/qx-showdown": "^1.8.7",
     "qooxdoo/qxl.testtapper": "^3.0.0",

--- a/frontend/source/class/agrammon/Changelog.js
+++ b/frontend/source/class/agrammon/Changelog.js
@@ -28,9 +28,9 @@ qx.Class.define("agrammon.Changelog", {
         qxShowdown.Load;
 
         this.addListenerOnce('appear', function() {
-           let req = new qx.io.remote.Request("doc/CHANGELOG.md");
-           req.addListener("completed", function (e) {
-                let md = e.getContent();
+           let req = new qx.io.request.Xhr("doc/CHANGELOG.md");
+           req.addListener("success", function (e) {
+                let md = e.getTarget().getResponseText();
                 let converter = new showdown.Converter();
                 docu.setHtml(converter.makeHtml(md));
             });

--- a/frontend/source/class/agrammon/io/remote/Rpc.js
+++ b/frontend/source/class/agrammon/io/remote/Rpc.js
@@ -9,27 +9,20 @@
 ************************************************************************ */
 
 /**
- * The Rpc class inherits from {@link qx.io.remote.Rpc}. It knows a bunch about
- * the way we like Rpc to happen in Agrammon context.
+ * Agrammon's RPC helper. It POSTs JSON to per-method endpoints via
+ * {@link qx.io.request.Xhr} and adds the login-retry / error handling we
+ * like in the Agrammon context.
+ *
+ * Historically this extended the deprecated qx.io.remote.Rpc, but callAsync
+ * has long been overridden to use qx.io.request.Xhr directly, so the base
+ * class was only a (qooxdoo 7.x deprecated) dependency. It now extends
+ * qx.core.Object.
  *
  * Derived from Tobi's Nequal Rpc.js
  */
 qx.Class.define('agrammon.io.remote.Rpc', {
-    extend : qx.io.remote.Rpc,
+    extend : qx.core.Object,
     type : 'singleton',
-
-    /**
-     * Create an instance of Rpc.
-     */
-    construct : function() {
-        this.base(arguments);
-
-        this.set({
-            timeout     : 25 * 1000,
-            url         : 'jsonrpc/',
-            serviceName : 'Agrammon'
-        });
-    },
 
     members : {
 

--- a/frontend/source/class/agrammon/module/output/Output.js
+++ b/frontend/source/class/agrammon/module/output/Output.js
@@ -40,7 +40,6 @@ qx.Class.define('agrammon.module.output.Output', {
 
         this.getOutputFunc = function(data,exc,id) {
             that.__running = false;
-            that.__rpc.setTimeout(that.__oldTimeout);
             if (exc == null) {
                 var pid = data.pid;
                 var session = data.sessionid;
@@ -107,7 +106,6 @@ qx.Class.define('agrammon.module.output.Output', {
 
     members : {
         __running: false,
-        __oldTimeout: null,
         getOutputFunc: null,
         outputIsValid: null,
         outputData: null,
@@ -175,8 +173,6 @@ qx.Class.define('agrammon.module.output.Output', {
                 qx.event.message.Bus.dispatchByName('agrammon.Output.dataReady', msg);
                 return;
             }
-            this.__oldTimeout = this.__rpc.getTimeout();
-            this.__rpc.setTimeout(600*1000);  // 10 minutes CPU limit
             this.__rpc.callAsync(this.getOutputFunc, 'get_output_variables', { datasetName: datasetName} );
             return;
         }

--- a/frontend/source/class/agrammon/ui/menu/NavMenu.js
+++ b/frontend/source/class/agrammon/ui/menu/NavMenu.js
@@ -54,43 +54,6 @@ qx.Class.define('agrammon.ui.menu.NavMenu', {
                       );
         }, this);
 
-        var that=this;
-        this.testFunc = function(data,exc,id) {
-            if (exc == null) {
-                that.debug('testFunc: data='+data);
-            }
-            else {
-                if (exc.code == qx.io.remote.Rpc.localError.timeout) {
-                    alert('Timeout in testFunc()');
-                }
-                else {
-                    alert(exc);
-                }
-            }
-        };
-
-        var testCmd  = new qx.ui.command.Command;
-        testCmd.addListener("execute", function(e) {
-            var rpc = agrammon.io.remote.Rpc.getInstance();
-            rpc.setTimeout(3000);
-            rpc.addListener('completed', function(e) {
-                var data = e.getData();
-                for (var k in data) {
-                    this.debug('k='+k);
-                }
-                alert('rpc completed: data='+e.getData().result);
-            }, this);
-            rpc.addListener('failed', function(e) {
-                alert('rpc failed, ex='+e.getData().toString());
-            }, this);
-            rpc.addListener('timeout', function(e) {
-                alert('rpc timeout, ex='+e.getData().toString());
-            }, this);
-//            rpc.callAsyncListeners(true, 'timeout', 2);
-//            rpc.callAsyncListeners(false, 'timeout', 2);
-            rpc.callAsync(this.testFunc, 'timeout', 2);
-        }, this);
-
         this.__addButton =
             new qx.ui.menu.Button(this.tr("Add instance"),
                                   null, addCmd);
@@ -106,16 +69,12 @@ qx.Class.define('agrammon.ui.menu.NavMenu', {
 //        this.__checkButton =
 //            new qx.ui.menu.Button(this.tr("Check instance"),
 //                                  null, checkCmd);
-//        this.__testButton =
-//            new qx.ui.menu.Button(this.tr("Test"),
-//                                  null, testCmd);
         this.add(this.__addButton);
         this.add(this.__copyButton);
         this.add(this.__renButton);
         this.add(this.__delButton);
         this.add(new qx.ui.menu.Separator());
 //        this.add(this.__checkButton);
-//        this.add(this.__testButton);
 
         this.addListener("appear",  function(e) {
             var selectedFolder = this.__navTree.getSelection()[0];


### PR DESCRIPTION
Closes #643.

Qooxdoo's `qx.io.remote.*` is deprecated and, on qooxdoo 7.x, only available through the optional `qooxdoo/deprecated.qx.io.remote` library. Agrammon doesn't actually need it: `agrammon.io.remote.Rpc.callAsync` was overridden long ago to use `qx.io.request.Xhr` (per-method JSON POST), so the qx1 RPC protocol was never on the wire — only the class inheritance and a few stray API uses remained.

Unlike CallBackery [PR #242](https://github.com/oetiker/callbackery/pull/242), which genuinely spoke qx1 and was rewritten onto `qx.io.jsonrpc.Client` (with the JSON-RPC 2.0 dispatcher inherited from `Mojolicious::Plugin::Qooxdoo`), Agrammon's transport is already plain JSON-over-POST against 17 Cro REST routes. So this is a scoped dependency removal, **not** a protocol change.

## Changes (frontend only)
- **`io/remote/Rpc.js`** — extend `qx.core.Object` instead of `qx.io.remote.Rpc`; drop the vestigial `construct()` that set `timeout`/`url`/`serviceName` (none used by the Xhr-based `callAsync`).
- **`Changelog.js`** — fetch `CHANGELOG.md` via `qx.io.request.Xhr` instead of the deprecated `qx.io.remote.Request`.
- **`ui/menu/NavMenu.js`** — remove the dead `testFunc`/`testCmd` debug block (never added to the menu; the last user of `qx.io.remote.Rpc.localError.timeout` and the old `completed`/`failed`/`timeout` event API).
- **`module/output/Output.js`** — remove the `setTimeout(600s)`/`getTimeout`/`__oldTimeout` plumbing. It was a no-op: the Xhr-based `callAsync` never reads the singleton's `timeout`, so the "10 minutes CPU limit" never applied. (The intended long-run timeout being silently broken is a pre-existing latent issue, intentionally left out of this PR.)
- **`Manifest.json`** — drop the `qooxdoo/deprecated.qx.io.remote` requirement.

## Verification
- No `qx.io.remote` references remain in `frontend/source` (only a doc comment).
- Frontend compiles clean on qooxdoo 7.8.0 **without** the deprecated library (`npx qx compile --target=source`).
- GUI smoke-tested: Changelog dialog renders, login + dataset load, and model run → Output all work.
- No wire-protocol or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)