### PR TITLE
test: fix two stale webservice assertions

### DIFF
--- a/lib/Agrammon/Config.rakumod
+++ b/lib/Agrammon/Config.rakumod
@@ -161,7 +161,7 @@ class Agrammon::Config {
             $v ~~ Associative && $v<title>
                 ?? %( |$v, title => %( $v<title>.map({ .key => .value.subst('%VERSION%', ~($v<version> // ''), :g) }) ) )
                 !! $v
-        }).list;
+        }).Array;
     }
 
     # User-visible short version label (e.g. '7.0'). Distinct from

--- a/t/webservice.rakutest
+++ b/t/webservice.rakutest
@@ -504,7 +504,7 @@ transactionally {
 
                     # These variables should have all the same elements
                     next unless $var ~~ / '::animals' /;
-                    is-deeply $input.keys.sort, qw|branch defaults enum enumAliases filter gui help labels models options optionsLang order type units validator variable|,
+                    is-deeply $input.keys.sort, qw|branch defaults enumAliases filter gui help labels models options optionsLang order type units validator variable|,
                         "$var has expected keys";
                     subtest "$var" => {
                         is $input<branch>, 'false', 'branch is false';


### PR DESCRIPTION
Two pre-existing `t/webservice.rakutest` failures (unrelated to each other), now fixed. Both failed identically on `main` before this change.

- **`get-cfg()`** — `Config.versions-resolved` returned a `List`; `is-deeply` against the test's empty-array `[]` expectation failed on container type. Now returns an `Array`. JSON output and the `config-version-template` tests are unaffected.
- **`Get model data`** — the test asserted the `::animals` input metadata includes an `enum` key, but `Input.as-hash` intentionally dropped it in #301 (it duplicated `options`/`optionsLang` and was unused by the GUI). Removed `enum` from the expected key set.

`t/webservice.rakutest` now passes 54/54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)