### PR TITLE
ci: parallelize the test suite (prove6 -j)

### DIFF
--- a/.github/workflows/backend-and-models.yml
+++ b/.github/workflows/backend-and-models.yml
@@ -126,6 +126,18 @@ jobs:
           # holds platform/compiler-specific precompiled bytecode.
           key: AgrammonModels-${{ matrix.os }}-${{ matrix.raku-version }}-${{ hashFiles('share/Models/**', 't/test-data/Models/**') }}
 
+      # On a model-cache miss, build the shared ~/.agrammon model cache once
+      # single-threaded: the parallel test run below must only ever read it, not
+      # race to build it concurrently. DB tests skip under AGRAMMON_UNIT_TEST, so
+      # this is just the model-loading warm-up. Skipped when the cache restored.
+      - name: Warm model cache (cold runs only)
+        if: steps.modelCache.outputs.cache-hit != 'true'
+        run: |
+          AGRAMMON_UNIT_TEST=1 RAKULIB=inst#$GITHUB_WORKSPACE/.raku $GITHUB_WORKSPACE/.raku/bin/prove6 -l t
+
       - name: Run backend tests
         run: |
-          RAKULIB=inst#$GITHUB_WORKSPACE/.raku $GITHUB_WORKSPACE/.raku/bin/prove6 -l t
+          # -j4 matches the GitHub-hosted runner's vCPUs. Tests are parallel-safe:
+          # DB-backed files use per-process-unique usernames, and the model cache
+          # is pre-built (restored or warmed above) so it is read-only here.
+          RAKULIB=inst#$GITHUB_WORKSPACE/.raku $GITHUB_WORKSPACE/.raku/bin/prove6 -l -j4 t

--- a/t/01-transactionally.rakutest
+++ b/t/01-transactionally.rakutest
@@ -27,7 +27,9 @@ subtest 'Connect to database' => {
 
 transactionally {
 
-    my $username  = 'agtest';
+    # Unique per test process so DB-backed tests can run in parallel (prove6 -j)
+    # without colliding on the globally-unique pers_email.
+    my $username  = "agtest_$*PID";
     my $password = 'XP123456';
     my ($uid, $key);
 

--- a/t/dataset.rakutest
+++ b/t/dataset.rakutest
@@ -75,6 +75,11 @@ subtest 'Create dataset' => {
 }
 
 transactionally {
+    # Unique per test process so DB-backed tests can run in parallel (prove6 -j)
+    # without colliding on the globally-unique pers_email. (Dataset/tag names are
+    # per-user, so they stay as-is once the owner is unique.)
+    my $username  = "agtest_$*PID";
+    my $username2 = "agtest2_$*PID";
     my $dataset-name = 'agtest';
     my $password = 'XP123456';
     my $uid;
@@ -85,7 +90,7 @@ transactionally {
     subtest 'create-account()' => {
         plan 3;
         ok $user = Agrammon::DB::User.new(
-                :username<agtest>,
+                :username($username),
                 :firstname<XF>,
                 :lastname<XL>,
                 :organisation<XO>,
@@ -477,7 +482,7 @@ transactionally {
         my $name = 'ScopeOwner';
 
         my $user2 = Agrammon::DB::User.new(
-            :username<agtest2>, :firstname<YF>, :lastname<YL>,
+            :username($username2), :firstname<YF>, :lastname<YL>,
             :organisation<YO>, :password<YP123456>,
         );
         $user2.activate-account($user2.create-account('user'));

--- a/t/sessionuser.rakutest
+++ b/t/sessionuser.rakutest
@@ -47,7 +47,9 @@ subtest 'Create user' => {
 }
 
 transactionally {
-    my $username = 'agtest';
+    # Unique per test process so DB-backed tests can run in parallel (prove6 -j)
+    # without colliding on the globally-unique pers_email.
+    my $username = "agtest_$*PID";
     my $password = 'XP123456';
     my $uid;
     my $new-user;

--- a/t/user.rakutest
+++ b/t/user.rakutest
@@ -18,6 +18,12 @@ if %*ENV<AGRAMMON_UNIT_TEST> {
 my $*AGRAMMON-DB-CONNECTION;
 my $cfg;
 
+# Unique per test process so DB-backed tests can run in parallel (prove6 -j)
+# without colliding on the globally-unique pers_email.
+my $username  = "agtest_$*PID";
+my $username2 = "agtest2_$*PID";
+my $username3 = "agtest3_$*PID";
+
 subtest 'Connect to database' => {
     my $conninfo;
     my $cfg-file;
@@ -35,13 +41,13 @@ subtest 'Connect to database' => {
 
 subtest 'Create user' => {
     ok my $user = Agrammon::DB::User.new(
-        :username<agtest>,
+        :$username,
         :firstname<XF>,
         :lastname<XL>,
         :organisation<XO>,
         :password<XP123456>,
     ), 'Create new user';
-    is $user.username,     'agtest', 'User has correct username';
+    is $user.username,     $username, 'User has correct username';
     is $user.firstname,    'XF',     'User has correct firstname';
     is $user.lastname,     'XL',     'User has correct lastname';
     is $user.organisation, 'XO',     'User has correct organisation';
@@ -51,9 +57,6 @@ subtest 'Create user' => {
 }
 
 transactionally {
-    my $username  = 'agtest';
-    my $username2 = 'agtest2';
-    my $username3 = 'agtest3';
     my $password = 'XP123456';
     my ($uid, $uid2, $uid3, $key);
 

--- a/t/webservice.rakutest
+++ b/t/webservice.rakutest
@@ -30,7 +30,10 @@ if %*ENV<AGRAMMON_UNIT_TEST> {
 %*ENV<AGRAMMON_TESTING> = True;
 
 my $cfg-file = %*ENV<AGRAMMON_CFG> // "t/test-data/agrammon.cfg.yaml";
-my $username = 'agtest';
+# Unique per test process so DB-backed tests can run in parallel (prove6 -j)
+# without colliding on the globally-unique pers_email. Datasets/tags are
+# per-user, so they stay as-is once the owning user is unique.
+my $username = "agtest_$*PID";
 
 
 my $*AGRAMMON-DB-CONNECTION;
@@ -53,7 +56,7 @@ transactionally {
             :organisation<XO>,
             :password<XP123456>,
         ), 'Create new user';
-        is $user.username,     'agtest', 'User has correct username';
+        is $user.username,     $username, 'User has correct username';
         is $user.firstname,    'XF',     'User has correct firstname';
         is $user.lastname,     'XL',     'User has correct lastname';
         is $user.organisation, 'XO',     'User has correct organisation';
@@ -134,8 +137,8 @@ transactionally {
     }
 
     subtest "clone-dataset" => {
-        my $old-username = 'agtest';
-        my $new-username = 'agtest';
+        my $old-username = $username;
+        my $new-username = $username;
         my $old-dataset = 'MyTestDataset';
         my $new-dataset = 'MyTestDataset Kopie';
         lives-ok { $ws.clone-dataset($user, $old-username, $new-username, $old-dataset, $new-dataset) }, "Clone own dataset";
@@ -155,7 +158,7 @@ transactionally {
     my $newUser;
     subtest "create-account" => {
         my $key;
-        my $username = 'agtest2';
+        my $username = "agtest2_$*PID";
         ok $key = $ws.create-account(
             $username, 'myPassword',
             'Erika', 'Mustermann', 'MyOrg', 'user'
@@ -164,7 +167,7 @@ transactionally {
         ok $ws.activate-account($key), "Activate new user account";
         is $newUser.username, $username, "New user has right username=$username";
 
-        $username = 'agtest3';
+        $username = "agtest3_$*PID";
         ok $key= $ws.create-account(
             $username, 'myPassword',
             Any, Any, Any, 'user'
@@ -172,7 +175,7 @@ transactionally {
         $newUser = Agrammon::Web::SessionUser.new(:$username).load;
         is $newUser.username, $username, "New user has right username=$username";
 
-        $username = 'agtest4';
+        $username = "agtest4_$*PID";
         ok $key = $ws.create-account(
             $username, 'myPassword',
             Any, Any, Any, Any


### PR DESCRIPTION
Makes the DB-backed integration tests parallel-safe and runs the suite with `prove6 -j`, cutting test time substantially both locally and in CI.

## Problem
`prove6` runs each test file in its own **process**. The DB integration tests shared fixed usernames (`agtest`, `agtest2`…), which collide on the globally-unique `pers_email` when files run concurrently — so the suite could only run serially.

## Fix
Datasets and tags are scoped **per-person** (their unique indexes include `dataset_pers` / `tag_pers`), so making just the **usernames** unique per process isolates everything downstream. Each DB test file now derives usernames from `$*PID` (e.g. `"agtest_$*PID"`):
- `01-transactionally`, `sessionuser`, `user`, `dataset`, `webservice`.
- `datasource-db` needs no change — it reuses the committed baseline user (`test@agrammon.ch`) with a dataset name no other file uses, and each block rolls back.

## CI
- Run `prove6 -l -j4 t` (`-j4` matches the GitHub runner vCPUs).
- A **model-cache warm-up** step builds `~/.agrammon` single-threaded on a cache *miss* only, so parallel workers never race to build the shared cache (they read it). Skipped when the cache is restored (the common case after the cache-key fix).

## Verification
- The 6 DB files pass running **concurrently** (`prove6 -j6`, 117 tests).
- Full suite: **79s under `-j6` vs 300s serial**, all **571 tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)